### PR TITLE
set version in Makefile.

### DIFF
--- a/amneziawg-dkms.spec
+++ b/amneziawg-dkms.spec
@@ -40,6 +40,11 @@ many different circumstances. It runs over UDP.
 # Fix the Makefile for CentOS7 since it ships coreutils from 2013.
 sed -i 's/install .* -D -t\(.\+\) /mkdir -p \1 \&\& \0/' %{_builddir}/amneziawg-linux-kernel-module-%{version}/src/Makefile
 
+# Set version in dkms.conf and Makefile
+sed -i "s/^PACKAGE_VERSION=.*/PACKAGE_VERSION=\"%{version}\"/" %{_builddir}/amneziawg-linux-kernel-module-%{version}/src/dkms.conf
+sed -i "s/^MAKE\[0\]=\"make -C \/var\/lib\/dkms\/amneziawg\/.*/MAKE[0]=\"make -C \/var\/lib\/dkms\/amneziawg\/%{version}\/build\"/" %{_builddir}/amneziawg-linux-kernel-module-%{version}/src/dkms.conf
+sed -i "s/^WIREGUARD_VERSION = .*/WIREGUARD_VERSION = %{version}/" %{_builddir}/amneziawg-linux-kernel-module-%{version}/src/Makefile
+
 
 %build
 

--- a/kernel-tree-scripts/prepare-sources.sh
+++ b/kernel-tree-scripts/prepare-sources.sh
@@ -81,9 +81,11 @@ else
   rm -rf "${HOME}/.rpmmacros"
   [ -f "${HOME}/.rpmmacros.orig" ] && mv "${HOME}/.rpmmacros.orig" "${HOME}/.rpmmacros"
   cd ../BUILD || exit 255
+  cd "$(ls -d */)" || exit 255
+  cd "$(ls -d */)" || exit 255
 fi
 
-KERNEL_PATH=$(pwd)
+KERNEL_PATH="$(pwd)"
 popd > /dev/null 2>&1 || exit 1
 [ -e kernel ] && rm -f kernel
 ln -s "${KERNEL_PATH}" kernel


### PR DESCRIPTION
Fix kernel source directory and set version in makefile

DKMS amneziawg, installed from RPM packet from https://copr.fedorainfracloud.org/coprs/amneziavpn/amneziawg/
for Centos 8 and 9, EPEL 7,8 and 9.

The DKMS build fails with an error, but the package is considered installed.