### PR TITLE
Added readme notes how to add source repository for DEB822-source format

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,10 @@ This setting should persist for future and will not require repeating.
 
 ### Kernel sourcetree could not be found automatically
 
+> [!IMPORTANT]
+> If your OS is using [the new deb822-style repository format](https://manpages.debian.org/bookworm/apt/sources.list.5.en.html#DEB822-STYLE_FORMAT) (Ubuntu 24.04, Debian 12),
+> in order to add the repository with kernel sourcetree, go to your system's sourcelist file (e.g. `/etc/apt/sources.list.d/ubuntu.sources`) and replace `Types: deb` with `Types: deb deb-src`.
+
 In some rare cases, setup script may not find your kernel's sourcetree automatically. You may find appropriate sources by yourself
 then and link them to DKMS module sources, e.g.
 


### PR DESCRIPTION
Hello,
I've made some changes to README file.

Current stable LTS distributives of Ubuntu 24.04 and Debian 12 are using [the new file format](https://manpages.debian.org/bookworm/apt/sources.list.5.en.html#DEB822-STYLE_FORMAT) for apt source lists.

The changes are both the new system-repo source list file location, and the format.


In case of ubuntu, the default file is located in `/etc/apt/sources.list.d/ubuntu.sources` and it looks like this:
```
Types: deb deb-src
URIs: http://archive.ubuntu.com/ubuntu
Suites: noble noble-updates noble-backports
Components: main restricted universe multiverse
Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg

Types: deb deb-src
URIs: http://security.ubuntu.com/ubuntu
Suites: noble-security
Components: main restricted universe multiverse
Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg
```

This might not be obvious for some people given the new format.

I'm not sure if I should rewrite step 2 for both ubuntu and debian, given that some people are still using older systems.

So I've made a note about this in troubleshooting section, that is related for missing kernel sourcetree.