### PR TITLE
Fix dkms build one more time

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -4,7 +4,7 @@ Priority: optional
 Maintainer: unidentified attacker <ua@amnezia.org>
 Build-Depends:
  debhelper,
- dh-dkms,
+ dh-sequence-dkms | dh-dkms | dkms,
  dkms
 Standards-Version: 4.5.1
 Homepage: https://amnezia.org


### PR DESCRIPTION
Debian provides dh-sequence-dkms since at least 10, but Ubuntu does not at least in 20.04.

dh-dkms is also packaged separately only on the latest Ubuntu version.

Use "or" hack to select the most preferable package.