### PR TITLE
Makefile: Use simple assignment for KERNELRELEASE

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -4,7 +4,7 @@
 
 WIREGUARD_VERSION = 1.0.0
 
-KERNELRELEASE ?= $(shell uname -r)
+KERNELRELEASE := $(shell uname -r)
 KERNELDIR ?= /lib/modules/$(KERNELRELEASE)/build
 PREFIX ?= /usr
 DESTDIR ?=


### PR DESCRIPTION
GNU Make 4.4.1 on Arch Linux segfaults when encountering `You're running a modern Linux Kernel (version $(KERNELRELEASE)).`

It's fixed by using a simple assignment `:=` for `KERNELRELEASE` instead of a conditional assignment `?=`

**Behavior without the fix:**
![Stock](https://github.com/user-attachments/assets/926eea2d-6e7d-47d7-898e-65b59b5c29ce)

**Behavior with the fix:**
![Changed assignment](https://github.com/user-attachments/assets/606e58a8-a855-432a-b2dc-c98c39e81766)

**Verifying segfault source by removing the reference to the variable:**
![Removed reference](https://github.com/user-attachments/assets/97b210da-596c-48a2-acc4-bf4be0db36ea)
