### PR TITLE
Changes for Fedora 41

### DIFF
--- a/kernel-tree-scripts/prepare-sources.sh
+++ b/kernel-tree-scripts/prepare-sources.sh
@@ -90,6 +90,7 @@ else
   [ -f "${HOME}/.rpmmacros.orig" ] && mv "${HOME}/.rpmmacros.orig" "${HOME}/.rpmmacros"
   cd ../BUILD || exit 255
   cd_first
+  cd_first kernel
   cd_first linux
 fi
 


### PR DESCRIPTION
Looks like in Fedora 41 the structure of source rpms has changed a bit. I needed this to compile the module after the upgrade.