### PR TITLE
Broken DKMS autoinstall on newest Ubuntu and AmneziaWG kernel

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -42,7 +42,7 @@ define MODERN_KERNEL_SOURCES_NOT_FOUND_ERROR
 You're running a modern Linux Kernel (version $(KERNELRELEASE)).
 
 In order to build AmneziaWG kernel module for this kernel you must obtain sources of your kernel
-by yourself and make a symlink to them into this directory:
+by yourself and make a symlink to them into /var/lib/dkms/(amnezia folder)/build and /usr/src/(amnezia folder)/build directories:
 
     ln -s <path to kernel sources> kernel
 


### PR DESCRIPTION
Following the latest update, some users have reported issues on the newest Ubuntu versions due to unavailable kernel sources (and notifying in case of  `make` fails only about one active dir instead of both). This issue can be addressed through the following approaches:

Reworking the Code
Modify the code to rely exclusively on a single correct directory for kernel sources. In this case, the recommended directory would be /var/lib/dkms.

Enhancing the Installation Process
Simplify the auto-installation process by:

Identifying the kernel version of the host machine.
Downloading the required sources to a designated directory.
Creating symbolic links to both directories for compatibility.
Proceeding with the `make` process seamlessly.
User Notification
For a simpler solution, notify users of the two active directories where they should place their kernel sources. This option, while less automated, ensures clarity for the user.