### PR TITLE
Fix missing cd_first call in prepare-sources.sh

### DIFF
--- a/kernel-tree-scripts/prepare-sources.sh
+++ b/kernel-tree-scripts/prepare-sources.sh
@@ -90,6 +90,7 @@ else
   [ -f "${HOME}/.rpmmacros.orig" ] && mv "${HOME}/.rpmmacros.orig" "${HOME}/.rpmmacros"
   cd ../BUILD || exit 255
   cd_first
+  cd_first
   cd_first linux
 fi
 


### PR DESCRIPTION
Add a missing `cd_first` call in the `prepare-sources.sh` script to ensure proper directory navigation.