### PR TITLE
move hmac realization inside of noise.c as it was deleted from kernel

### DIFF
--- a/src/patches/008-move-hmac-inside.patch
+++ b/src/patches/008-move-hmac-inside.patch
@@ -1,0 +1,75 @@
+diff --git noise.c noise.c
+--- noise.c
++++ noise.c
+@@ -304,6 +304,35 @@
+ 		static_identity->static_public, private_key);
+ }
+ 
++static void hmac(u8 *out, const u8 *in, const u8 *key, const size_t inlen, const size_t keylen)
++{
++	struct blake2s_state state;
++	u8 x_key[BLAKE2S_BLOCK_SIZE] __aligned(__alignof__(u32)) = { 0 };
++	u8 i_hash[BLAKE2S_HASH_SIZE] __aligned(__alignof__(u32));
++	int i;
++	if (keylen > BLAKE2S_BLOCK_SIZE) {
++		blake2s_init(&state, BLAKE2S_HASH_SIZE);
++		blake2s_update(&state, key, keylen);
++		blake2s_final(&state, x_key);
++	} else
++		memcpy(x_key, key, keylen);
++	for (i = 0; i < BLAKE2S_BLOCK_SIZE; ++i)
++		x_key[i] ^= 0x36;
++	blake2s_init(&state, BLAKE2S_HASH_SIZE);
++	blake2s_update(&state, x_key, BLAKE2S_BLOCK_SIZE);
++	blake2s_update(&state, in, inlen);
++	blake2s_final(&state, i_hash);
++	for (i = 0; i < BLAKE2S_BLOCK_SIZE; ++i)
++		x_key[i] ^= 0x5c ^ 0x36;
++	blake2s_init(&state, BLAKE2S_HASH_SIZE);
++	blake2s_update(&state, x_key, BLAKE2S_BLOCK_SIZE);
++	blake2s_update(&state, i_hash, BLAKE2S_HASH_SIZE);
++	blake2s_final(&state, i_hash);
++	memcpy(out, i_hash, BLAKE2S_HASH_SIZE);
++	memzero_explicit(x_key, BLAKE2S_BLOCK_SIZE);
++	memzero_explicit(i_hash, BLAKE2S_HASH_SIZE);
++}
++
+ /* This is Hugo Krawczyk's HKDF:
+  *  - https://eprint.iacr.org/2010/264.pdf
+  *  - https://tools.ietf.org/html/rfc5869
+@@ -324,14 +353,14 @@
+ 		 ((third_len || third_dst) && (!second_len || !second_dst))));
+ 
+ 	/* Extract entropy from data into secret */
+-	blake2s256_hmac(secret, data, chaining_key, data_len, NOISE_HASH_LEN);
++	hmac(secret, data, chaining_key, data_len, NOISE_HASH_LEN);
+ 
+ 	if (!first_dst || !first_len)
+ 		goto out;
+ 
+ 	/* Expand first key: key = secret, data = 0x1 */
+ 	output[0] = 1;
+-	blake2s256_hmac(output, output, secret, 1, BLAKE2S_HASH_SIZE);
++	hmac(output, output, secret, 1, BLAKE2S_HASH_SIZE);
+ 	memcpy(first_dst, output, first_len);
+ 
+ 	if (!second_dst || !second_len)
+@@ -339,7 +368,7 @@
+ 
+ 	/* Expand second key: key = secret, data = first-key || 0x2 */
+ 	output[BLAKE2S_HASH_SIZE] = 2;
+-	blake2s256_hmac(output, output, secret, BLAKE2S_HASH_SIZE + 1,
++	hmac(output, output, secret, BLAKE2S_HASH_SIZE + 1,
+ 			BLAKE2S_HASH_SIZE);
+ 	memcpy(second_dst, output, second_len);
+ 
+@@ -348,7 +377,7 @@
+ 
+ 	/* Expand third key: key = secret, data = second-key || 0x3 */
+ 	output[BLAKE2S_HASH_SIZE] = 3;
+-	blake2s256_hmac(output, output, secret, BLAKE2S_HASH_SIZE + 1,
++	hmac(output, output, secret, BLAKE2S_HASH_SIZE + 1,
+ 			BLAKE2S_HASH_SIZE);
+ 	memcpy(third_dst, output, third_len);
+ 
+


### PR DESCRIPTION
Due to `blake2s_hmac` function was deleted from linux kernel crypto lib and was moved inside of wireguard realization amneziawg could not be build with linux kernel version higher than 5.15.43.

In this PR fixes same operations was applied as for wireguard in this commit  https://github.com/torvalds/linux/commit/d8d83d8ab0a453e17e68b3a3bed1f940c34b8646#diff-5da3b3ae7f16fc65df44e74e09f4aee5c369888625a32bdb98434a2971bf8999

Closes: https://github.com/amnezia-vpn/amneziawg-linux-kernel-module/issues/12