### PR TITLE
feat(junk): add protocol mimicry tags for DPI evasion

### DIFF
--- a/src/junk.c
+++ b/src/junk.c
@@ -8,6 +8,120 @@
 #include <linux/random.h>
 #include <linux/ktime.h>
 
+/*
+ * Protocol mimicry templates for DPI evasion
+ * These generate valid-looking protocol headers with randomized fields
+ */
+
+/* QUIC Initial packet template (RFC 9000) */
+static const u8 quic_template[] = {
+	0xc0,						/* Long header, Initial type */
+	0x00, 0x00, 0x00, 0x01,				/* Version: QUIC v1 */
+	0x08,						/* DCID length: 8 */
+	0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,	/* DCID placeholder */
+	0x08,						/* SCID length: 8 */
+	0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,	/* SCID placeholder */
+	0x00,						/* Token length: 0 */
+	0x44, 0xb4,					/* Length: 1200 (varint) */
+	0x00, 0x00, 0x00, 0x00				/* Packet number placeholder */
+};
+#define QUIC_DCID_OFFSET	6
+#define QUIC_SCID_OFFSET	15
+#define QUIC_PKTNUM_OFFSET	26
+#define QUIC_HEADER_SIZE	30
+#define QUIC_MIN_SIZE		1200
+
+/* DNS query template (RFC 1035) - google.com A record */
+static const u8 dns_template[] = {
+	0x00, 0x00,					/* Transaction ID placeholder */
+	0x01, 0x00,					/* Flags: standard query, RD */
+	0x00, 0x01,					/* Questions: 1 */
+	0x00, 0x00, 0x00, 0x00, 0x00, 0x00,		/* Answer/Auth/Add: 0 */
+	0x06, 'g', 'o', 'o', 'g', 'l', 'e',		/* Label: google */
+	0x03, 'c', 'o', 'm',				/* Label: com */
+	0x00,						/* Root terminator */
+	0x00, 0x01,					/* Type: A */
+	0x00, 0x01					/* Class: IN */
+};
+#define DNS_TXID_OFFSET		0
+#define DNS_SIZE		33
+
+/* TLS 1.3 ClientHello template (RFC 8446) */
+static const u8 tls_template[] = {
+	/* Record layer */
+	0x16,						/* Content type: Handshake */
+	0x03, 0x01,					/* Version: TLS 1.0 (compat) */
+	0x00, 0xb4,					/* Record length: 180 */
+	/* Handshake header */
+	0x01,						/* Type: ClientHello */
+	0x00, 0x00, 0xb0,				/* Length: 176 */
+	0x03, 0x03,					/* Version: TLS 1.2 */
+	/* 32-byte ClientRandom placeholder */
+	0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+	0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+	0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+	0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+	/* Session ID */
+	0x20,						/* Session ID length: 32 */
+	/* 32-byte Session ID placeholder */
+	0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+	0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+	0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+	0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+	/* Cipher suites */
+	0x00, 0x06,					/* Cipher suite length: 6 */
+	0x13, 0x01,					/* TLS_AES_128_GCM_SHA256 */
+	0x13, 0x02,					/* TLS_AES_256_GCM_SHA384 */
+	0x13, 0x03,					/* TLS_CHACHA20_POLY1305 */
+	/* Compression */
+	0x01, 0x00,					/* Compression: null */
+	/* Extensions */
+	0x00, 0x61,					/* Extensions length: 97 */
+	/* SNI extension (example.com) */
+	0x00, 0x00,					/* Type: server_name */
+	0x00, 0x10,					/* Length: 16 */
+	0x00, 0x0e,					/* SNI list length: 14 */
+	0x00,						/* Name type: hostname */
+	0x00, 0x0b,					/* Hostname length: 11 */
+	'e', 'x', 'a', 'm', 'p', 'l', 'e', '.', 'c', 'o', 'm',
+	/* supported_versions extension */
+	0x00, 0x2b,					/* Type: supported_versions */
+	0x00, 0x03,					/* Length: 3 */
+	0x02,						/* Versions length: 2 */
+	0x03, 0x04,					/* TLS 1.3 */
+	/* supported_groups extension */
+	0x00, 0x0a,					/* Type: supported_groups */
+	0x00, 0x04,					/* Length: 4 */
+	0x00, 0x02,					/* Groups length: 2 */
+	0x00, 0x1d,					/* x25519 */
+	/* key_share extension */
+	0x00, 0x33,					/* Type: key_share */
+	0x00, 0x26,					/* Length: 38 */
+	0x00, 0x24,					/* Client shares length: 36 */
+	0x00, 0x1d,					/* Group: x25519 */
+	0x00, 0x20,					/* Key length: 32 */
+	/* 32-byte key share placeholder */
+	0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+	0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+	0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+	0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+	/* signature_algorithms extension */
+	0x00, 0x0d,					/* Type: signature_algorithms */
+	0x00, 0x10,					/* Length: 16 */
+	0x00, 0x0e,					/* Algorithms length: 14 */
+	0x04, 0x03,					/* ecdsa_secp256r1_sha256 */
+	0x05, 0x03,					/* ecdsa_secp384r1_sha384 */
+	0x06, 0x03,					/* ecdsa_secp521r1_sha512 */
+	0x02, 0x03,					/* ecdsa_sha1 */
+	0x08, 0x04,					/* rsa_pss_rsae_sha256 */
+	0x08, 0x05,					/* rsa_pss_rsae_sha384 */
+	0x08, 0x06					/* rsa_pss_rsae_sha512 */
+};
+#define TLS_RANDOM_OFFSET	11
+#define TLS_SESSID_OFFSET	44
+#define TLS_KEYSHARE_OFFSET	133
+#define TLS_SIZE		185
+
 static int parse_b_tag(char* val, struct list_head* head) {
     int err;
     int i;
@@ -181,6 +295,115 @@ static int parse_rd_tag(char* val, struct list_head* head) {
     return 0;
 }
 
+/*
+ * Protocol mimicry modifiers - randomize dynamic fields at send time
+ */
+
+/* QUIC: Randomize DCID, SCID, packet number, and padding */
+static void quic_modifier(char *buf, int len, struct wg_peer *peer)
+{
+	get_random_bytes(buf + QUIC_DCID_OFFSET, 8);
+	get_random_bytes(buf + QUIC_SCID_OFFSET, 8);
+	get_random_bytes(buf + QUIC_PKTNUM_OFFSET, 4);
+	if (len > QUIC_HEADER_SIZE)
+		get_random_bytes(buf + QUIC_HEADER_SIZE, len - QUIC_HEADER_SIZE);
+}
+
+static int parse_quic_tag(char *val, struct list_head *head)
+{
+	struct jp_tag *tag;
+	u8 *pkt;
+
+	if (val)
+		return -EINVAL;
+
+	pkt = kmalloc(QUIC_MIN_SIZE, GFP_KERNEL);
+	if (!pkt)
+		return -ENOMEM;
+
+	memcpy(pkt, quic_template, QUIC_HEADER_SIZE);
+	memset(pkt + QUIC_HEADER_SIZE, 0, QUIC_MIN_SIZE - QUIC_HEADER_SIZE);
+
+	tag = kzalloc(sizeof(*tag), GFP_KERNEL);
+	if (!tag) {
+		kfree(pkt);
+		return -ENOMEM;
+	}
+
+	tag->pkt = pkt;
+	tag->pkt_size = QUIC_MIN_SIZE;
+	tag->func = quic_modifier;
+
+	list_add(&tag->head, head);
+	return 0;
+}
+
+/* DNS: Randomize transaction ID */
+static void dns_modifier(char *buf, int len, struct wg_peer *peer)
+{
+	get_random_bytes(buf + DNS_TXID_OFFSET, 2);
+}
+
+static int parse_dns_tag(char *val, struct list_head *head)
+{
+	struct jp_tag *tag;
+	u8 *pkt;
+
+	if (val)
+		return -EINVAL;
+
+	pkt = kmemdup(dns_template, DNS_SIZE, GFP_KERNEL);
+	if (!pkt)
+		return -ENOMEM;
+
+	tag = kzalloc(sizeof(*tag), GFP_KERNEL);
+	if (!tag) {
+		kfree(pkt);
+		return -ENOMEM;
+	}
+
+	tag->pkt = pkt;
+	tag->pkt_size = DNS_SIZE;
+	tag->func = dns_modifier;
+
+	list_add(&tag->head, head);
+	return 0;
+}
+
+/* TLS: Randomize ClientRandom, SessionID, and key_share */
+static void tls_modifier(char *buf, int len, struct wg_peer *peer)
+{
+	get_random_bytes(buf + TLS_RANDOM_OFFSET, 32);
+	get_random_bytes(buf + TLS_SESSID_OFFSET, 32);
+	get_random_bytes(buf + TLS_KEYSHARE_OFFSET, 32);
+}
+
+static int parse_tls_tag(char *val, struct list_head *head)
+{
+	struct jp_tag *tag;
+	u8 *pkt;
+
+	if (val)
+		return -EINVAL;
+
+	pkt = kmemdup(tls_template, TLS_SIZE, GFP_KERNEL);
+	if (!pkt)
+		return -ENOMEM;
+
+	tag = kzalloc(sizeof(*tag), GFP_KERNEL);
+	if (!tag) {
+		kfree(pkt);
+		return -ENOMEM;
+	}
+
+	tag->pkt = pkt;
+	tag->pkt_size = TLS_SIZE;
+	tag->func = tls_modifier;
+
+	list_add(&tag->head, head);
+	return 0;
+}
+
 int jp_parse_tags(char* str, struct list_head* head) {
     int err = 0;
     char* key;
@@ -222,6 +445,21 @@ int jp_parse_tags(char* str, struct list_head* head) {
         }
         else if (!strcmp(key, "rd")) {
             err = parse_rd_tag(val, head);
+            if (err)
+                return err;
+        }
+        else if (!strcmp(key, "quic")) {
+            err = parse_quic_tag(val, head);
+            if (err)
+                return err;
+        }
+        else if (!strcmp(key, "dns")) {
+            err = parse_dns_tag(val, head);
+            if (err)
+                return err;
+        }
+        else if (!strcmp(key, "tls")) {
+            err = parse_tls_tag(val, head);
             if (err)
                 return err;
         }


### PR DESCRIPTION
## Summary

- Add `<quic>`, `<dns>`, and `<tls>` tags for one-line protocol mimicry
- Eliminates need for manual Wireshark capture of hex blobs
- Static RFC-compliant templates with dynamic field randomization at send time

## New Tags

| Tag | Protocol | Size | Randomized Fields | RFC |
|-----|----------|------|-------------------|-----|
| `<quic>` | QUIC Initial | 1200 bytes | DCID, SCID, packet number, padding | 9000 |
| `<dns>` | DNS Query | 33 bytes | Transaction ID | 1035 |
| `<tls>` | TLS 1.3 ClientHello | 185 bytes | ClientRandom, SessionID, key_share | 8446 |

## Usage Example

```ini
[Interface]
PrivateKey = ...
I1 = <quic>
I2 = <dns>
I3 = <tls>
```

## Implementation Details

- 238 lines of kernel code in `src/junk.c`
- Uses `get_random_bytes()` for cryptographic randomness
- Modifier functions called at packet send time
- Backward compatible with existing tags (`<b>`, `<c>`, `<t>`, `<r>`, `<rc>`, `<rd>`)

## Test Plan

- [ ] Kernel module compiles without warnings
- [ ] Tags parse correctly in config
- [ ] Wireshark shows valid protocol headers
- [ ] Dynamic fields change per-packet

🤖 Generated with [Claude Code](https://claude.com/claude-code)