### PR TITLE
fix: use ifdef for COMPAT_CANNOT_USE_PCPU_STAT_TYPE

### DIFF
--- a/src/device.c
+++ b/src/device.c
@@ -246,7 +246,9 @@ static const struct net_device_ops netdev_ops = {
 	.ndo_open		= wg_open,
 	.ndo_stop		= wg_stop,
 	.ndo_start_xmit		= wg_xmit,
+#ifdef COMPAT_CANNOT_USE_PCPU_STAT_TYPE
 	.ndo_get_stats64 = dev_get_tstats64
+#endif
 };
 
 static void wg_destruct(struct net_device *dev)


### PR DESCRIPTION
The compatibility guard breaks ndo_get_stats64 registration on recent kernels, causing missing or incorrect network statistics reporting.

This resolves [issue #120](https://github.com/amnezia-vpn/amneziawg-linux-kernel-module/issues/120).

The change [was tested](https://github.com/Slava-Shchipunov/awg-openwrt/issues/78) in OpenWrt builds, where the module works correctly and network statistics are reported as expected ([link to patch](https://github.com/Slava-Shchipunov/awg-openwrt/blob/master/kmod-amneziawg/patches/001-fix-stats-compat.patch)).
