### PR TITLE
Use newer and more secure installation methods for Debian

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,12 +36,24 @@ Open `Terminal` and do next steps:
    at least one line starting with `deb-src` is present and uncommented.
 3. Execute following commands:
 ```shell
-sudo apt install -y software-properties-common python3-launchpadlib gnupg2 linux-headers-$(uname -r)
-sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 57290828
-echo "deb https://ppa.launchpadcontent.net/amnezia/ppa/ubuntu focal main" | sudo tee -a /etc/apt/sources.list
-echo "deb-src https://ppa.launchpadcontent.net/amnezia/ppa/ubuntu focal main" | sudo tee -a /etc/apt/sources.list
+sudo apt-get install --yes gnupg2 apt-transport-https
+gpg --keyserver keyserver.ubuntu.com --recv-keys 75c9dd72c799870e310542e24166f2c257290828
+gpg --export 75c9dd72c799870e310542e24166f2c257290828 | sudo tee /usr/share/keyrings/amnezia.gpg > /dev/null
+sudo tee /etc/apt/sources.list.d/amnezia.sources <<EOF
+Types: deb deb-src
+URIs: https://ppa.launchpadcontent.net/amnezia/ppa/ubuntu
+Suites: focal
+Components: main
+Signed-By: /usr/share/keyrings/amnezia.gpg
+EOF
 sudo apt-get update
-sudo apt-get install -y amneziawg
+sudo apt-get install --yes amneziawg amneziawg-tools
+```
+
+For Debian 12 or older, you can use the following command instead of `sudo tee /etc/apt/sources.list.d/amnezia.sources`:
+```
+echo "deb [signed-by=/usr/share/keyrings/amnezia.gpg] https://ppa.launchpadcontent.net/amnezia/ppa/ubuntu focal main" | sudo tee -a /etc/apt/sources.list.d/amnezia.list
+echo "deb-src [signed-by=/usr/share/keyrings/amnezia.gpg] https://ppa.launchpadcontent.net/amnezia/ppa/ubuntu focal main" | sudo tee -a /etc/apt/sources.list.d/amnezia.list
 ```
 
 ### Linux Mint


### PR DESCRIPTION
Debian 13 has a new package format (DEB822). This was taken into account in the PR. An alternative command was specified for older Debian versions. Storing the key file separately is currently the recommended method; the method using apt-key is deprecated. Specifying the complete fingerprint of the key increases security without additional effort on the part of the user (see also https://soatok.blog/2026/01/07/practical-collision-attack-against-long-key-ids-in-pgp/).

Closes https://github.com/amnezia-vpn/amneziawg-linux-kernel-module/pull/27