### PR TITLE
Fix network stats reported for default 6.8 kernels on Ubuntu 24.04 LTS

### DIFF
--- a/src/compat/compat.h
+++ b/src/compat/compat.h
@@ -1319,7 +1319,7 @@ static inline void netif_threaded_enable(struct net_device *dev) { }
 #define CONFIG_PM_USERSPACE_AUTOSLEEP CONFIG_ANDROID
 #endif
 
-#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 7, 0)
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 9, 0)
 #define COMPAT_CANNOT_USE_PCPU_STAT_TYPE
 #endif
 


### PR DESCRIPTION
Driver has compat `COMPAT_CANNOT_USE_PCPU_STAT_TYPE` switch, where new reporting method is activated for modern kernels (see issue #120 and PR #129 ). 

Ubuntu 24.04 has kernel version 6.8.0-100 as default via `linux-image` package where `tstats` reporting method looks broken, and compat mode has to be relaxed to cover 6.8 kernels as well.

Default Ubuntu 24.04 behavior:

```bash
$ uname -a
Linux test 6.8.0-100-generic #100-Ubuntu SMP PREEMPT_DYNAMIC Tue Jan 13 16:40:06 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux

$ dmesg
[ 1159.610796] amneziawg: module verification failed: signature and/or required key missing - tainting kernel
[ 1159.612042] amneziawg: AmneziaWG 1.0.20251009 loaded. See amnezia.org for information.
[ 1159.612044] amneziawg: Copyright (C) 2015-2019 Jason A. Donenfeld <Jason@zx2c4.com>. All Rights Reserved.
[ 1159.612045] amneziawg: Copyright (C) 2024-2025 AmneziaVPN <admin@amnezia.org>. All Rights Reserved.

# Ifconfig reports zero traffic:
$ ifconfig
test: flags=209<UP,POINTOPOINT,RUNNING,NOARP>  mtu 1420
        inet 1.2.3.4  netmask 255.255.255.255  destination 4.3.2.1
        unspec 00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00  txqueuelen 1000  (UNSPEC)
        RX packets 0  bytes 0 (0.0 B)
        RX errors 0  dropped 0  overruns 0  frame 0
        TX packets 0  bytes 0 (0.0 B)
        TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0

# While AmneziaWG works and reports traffic correctly:
$ awg
peer: XXXYYY
  endpoint: 1.1.1.1:8000
  allowed ips: 0.0.0.0/0
  latest handshake: 11 seconds ago
  transfer: 1.31 KiB received, 20.44 KiB sent
```

With `COMPAT_CANNOT_USE_PCPU_STAT_TYPE` activated:

```bash
# Ifconfig reports correct values

test: flags=209<UP,POINTOPOINT,RUNNING,NOARP>  mtu 1420
        inet 1.2.3.4  netmask 255.255.255.255  destination 4.3.2.1
        unspec 00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00  txqueuelen 1000  (UNSPEC)
        RX packets 7  bytes 892 (892.0 B)
        RX errors 0  dropped 0  overruns 0  frame 0
        TX packets 84  bytes 20890 (20.8 KB)
        TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0
```

I have rechecked code in `device.c`, the `NETDEV_PCPU_STAT_TSTATS` flag is defined and used correctly and has to be supported by 6.8. kernel. Likely this problem is Ubuntu-specific. Problem is fixed in `6.11.0-17-generic` kernel (the next minor version avaliable, there is no 9 and 10 versions available).

This issue looks critical, as reporting breaks monitoring and observing using actual default Ubuntu LTS packages.