### PR TITLE
fix: free old buffers and reset mods_size in jp_spec_setup

### DIFF
--- a/src/junk.c
+++ b/src/junk.c
@@ -281,14 +281,17 @@ int jp_spec_setup(struct jp_spec *spec) {
         goto error;
     }
 
+    kfree(spec->pkt);
+    kfree(spec->mods);
+    spec->pkt_size = 0;
+    spec->mods_size = 0;
+
     spec->pkt = kzalloc(pkt_size, GFP_KERNEL);
     spec->mods = kzalloc(mods_size * sizeof(*spec->mods), GFP_KERNEL);
     if (!spec->pkt || !spec->mods) {
         err = -ENOMEM;
         goto error;
     }
-
-    spec->pkt_size = 0;
     list_for_each_entry_reverse(tag, &head, head) {
         if (tag->pkt) {
             memcpy(spec->pkt + spec->pkt_size, tag->pkt, tag->pkt_size);


### PR DESCRIPTION
## Problem

`jp_spec_setup()` is called every time the AWG interface configuration changes. On repeated calls, the function allocates new `spec->pkt` and `spec->mods` buffers **without freeing the old ones first** and without resetting `spec->mods_size`. This causes:

1. **Memory leak** - old buffers orphaned on every reconfiguration.
2. **Heap buffer overflow** - `spec->mods_size` retains its value from the previous call, causing `list_for_each_entry_reverse` to write past the newly allocated buffer.

Observed in production: `refill_obj_stock` crashed with page fault on corrupted kernel pointer, leading to `BUG: scheduling while atomic` and RCU stall persisting until manual reboot.

## Prior fix

Commit 87a06ff (`fix: memleak in jp_spec_setup due to uninit pkt_size`) added `spec->pkt_size = 0`. This PR addresses the remaining issues.

## Fix

Free both old buffers and reset both size fields before allocating new ones:

`c
kfree(spec->pkt);
kfree(spec->mods);
spec->pkt_size = 0;
spec->mods_size = 0;

spec->pkt  = kzalloc(pkt_size, GFP_KERNEL);
spec->mods = kzalloc(mods_size * sizeof(*spec->mods), GFP_KERNEL);
`

## Testing

Verified on Ubuntu 24.04 (kernel 6.8.0-100-generic, amneziawg DKMS 1.0.0). Server ran stable under repeated `awg syncconf` calls without heap corruption or memory growth.

---
@coderabbitai ignore