### PR TITLE
Fix: Junk packets can go in wrong order if device is behind QoS

### DIFF
--- a/src/messages.h
+++ b/src/messages.h
@@ -126,6 +126,9 @@ enum message_alignments {
 #define DATA_PACKET_HEAD_ROOM \
 	ALIGN(sizeof(struct message_data) + SKB_HEADER_LEN, 4)
 
-enum { HANDSHAKE_DSCP = 0x88 /* AF41, plus 00 ECN */ };
+enum {
+	HANDSHAKE_DSCP = 0x88, /* AF41, plus 00 ECN */
+	JUNK_DSCP = 0xb8, /* EF, plus 00 ECN */
+};
 
 #endif /* _WG_MESSAGES_H */

--- a/src/send.c
+++ b/src/send.c
@@ -30,7 +30,6 @@ static void wg_packet_send_handshake_initiation(struct wg_peer *peer)
 	struct message_handshake_initiation packet;
 	struct wg_device *wg = peer->device;
 	void *buffer;
-	u8 ds;
 	u16 junk_packet_count, junk_packet_size;
 	int i;
 	struct jp_spec* spec;
@@ -53,7 +52,7 @@ static void wg_packet_send_handshake_initiation(struct wg_peer *peer)
 		if (spec->pkt_size > 0) {
 			mutex_lock(&spec->lock);
 			jp_spec_applymods(spec, peer);
-			wg_socket_send_buffer_to_peer(peer, spec->pkt, spec->pkt_size, 0, 0, false);
+			wg_socket_send_buffer_to_peer(peer, spec->pkt, spec->pkt_size, JUNK_DSCP, 0, false);
 			atomic_inc(&peer->jp_packet_counter);
 			mutex_unlock(&spec->lock);
 		}
@@ -71,8 +70,7 @@ static void wg_packet_send_handshake_initiation(struct wg_peer *peer)
 			junk_packet_size = (u16) get_random_u32_inclusive(wg->jmin, wg->jmax);
 
 			get_random_bytes(buffer, junk_packet_size);
-			get_random_bytes(&ds, 1);
-			wg_socket_send_buffer_to_peer(peer, buffer, junk_packet_size, ds, 0, false);
+			wg_socket_send_buffer_to_peer(peer, buffer, junk_packet_size, JUNK_DSCP, 0, false);
 		}
 
 		kfree(buffer);


### PR DESCRIPTION
## Description 
WG handshake packets have `AF41` priority while I1-I5 are `CS0` and JC is a `random` value. This behaviour can cause handshake to be processed before all other packets on a device with QoS enabled and break junk flow (on the screenshot). Thus TSPU will apply throttling policies to the flow.

<img width="3326" height="426" alt="packets chaos" src="https://github.com/user-attachments/assets/4c214bcc-61e5-431d-a9b6-b0450a5ec095" />

## Fix 
Replace invalid DSCP values with `EF` (which is more prioritized than `AF41`) for junk and leave handshake one (AF41) as is.

