### PR TITLE
fix: improve 6.19 compatibility and add netlink diagnostics

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,154 @@
+# AGENTS.md
+
+Repository guide for agentic coding tools working in `amneziawg-linux-kernel-module`.
+
+## Scope And Layout
+
+- Kernel module sources live in `src/`.
+- Primary module objects are declared in `src/Kbuild` as `amneziawg-y := ...`.
+- Compatibility shims for older kernels live in `src/compat/`.
+- Integration tests live in `src/tests/`:
+  - `src/tests/netns.sh` (network namespace integration suite).
+  - `src/tests/qemu/Makefile` (QEMU-based cross-arch integration run).
+
+## Environment Assumptions
+
+- Most commands are expected to run from `src/` unless noted.
+- Building requires kernel headers or full kernel tree (see `README.md`).
+- Many tests require root privileges and kernel networking capabilities.
+- QEMU tests download/build distfiles and can take significant time/disk.
+
+## Build Commands
+
+- Build module:
+  - `make -C src`
+- Build with verbose debug flags:
+  - `make -C src debug`
+- Clean module artifacts:
+  - `make -C src clean`
+- Install module into current kernel modules path:
+  - `sudo make -C src install`
+- Install DKMS source payload:
+  - `make -C src dkms-install`
+
+## Lint / Static Analysis Commands
+
+- Kernel style check (checkpatch):
+  - `make -C src style`
+- Sparse/scan-build style static checking:
+  - `make -C src check`
+- Coccinelle report mode:
+  - `make -C src coccicheck`
+
+## Test Commands
+
+- Main integration test (network namespaces):
+  - `sudo make -C src test`
+  - Equivalent direct script: `sudo src/tests/netns.sh`
+- QEMU integration test:
+  - `make -C src test-qemu`
+- QEMU test for one architecture (closest equivalent to single-target run):
+  - `make -C src/tests/qemu ARCH=x86_64 qemu`
+  - Swap `ARCH` for supported values: `x86_64`, `i686`, `arm`, `armeb`, `aarch64`, `aarch64_be`, `mips`, `mipsel`, `mips64`, `mips64el`, `powerpc64le`, `powerpc`, `m68k`.
+
+## Running A Single Test
+
+There is no unit-test framework with per-test selectors in this repository.
+
+- `src/tests/netns.sh` runs as one large integration scenario (no `--filter` equivalent).
+- `src/tests/qemu/Makefile` runs one integration scenario per QEMU invocation.
+- Practical "single test" options:
+  - Run only one test family: `sudo make -C src test` or `make -C src test-qemu`.
+  - Run one QEMU arch target: `make -C src/tests/qemu ARCH=x86_64 qemu`.
+  - For style checks on one file, run checkpatch script directly from kernel tree:
+    - `"$KERNELDIR"/scripts/checkpatch.pl -f src/noise.c`
+
+## Developer Workflow (Recommended)
+
+1. `make -C src clean`
+2. `make -C src` (or `make -C src debug`)
+3. `make -C src style`
+4. `make -C src check` (when touching tricky logic or concurrency)
+5. `sudo make -C src test` for integration validation
+
+## Code Style Guidelines
+
+These are derived from existing code and Linux kernel conventions used in `src/*.c` and `src/*.h`.
+
+### Language And Tooling
+
+- Use C for kernel code; avoid introducing C++ or userspace-only patterns.
+- Keep code compatible with the existing kernel compatibility layer in `src/compat/`.
+- Do not add dependencies on userspace package managers.
+
+### Includes / Imports
+
+- Include local project headers first (e.g., `"device.h"`, `"noise.h"`).
+- Include kernel/system headers after local headers.
+- Keep include groups stable and minimal; remove unused includes.
+- Prefer module-local headers over deep includes when an abstraction exists.
+
+### Formatting
+
+- Follow Linux kernel formatting style:
+  - Tabs for indentation.
+  - Braces on their own lines for functions and control blocks.
+  - Keep wrapping consistent with nearby code.
+- Keep lines readable; do not optimize for extreme compactness.
+- Use existing SPDX header style for new source files.
+
+### Naming Conventions
+
+- Public module symbols use `wg_` prefix (e.g., `wg_noise_init`).
+- Use descriptive snake_case for variables and function names.
+- Constants/macros use upper snake case.
+- Keep names aligned with existing subsystem terms (`peer`, `handshake`, `keypair`, `endpoint`).
+
+### Types And Data Handling
+
+- Use kernel fixed-width types (`u8`, `u32`, `u64`, etc.) where appropriate.
+- Use `bool` for boolean state.
+- Respect endianness conversions (`cpu_to_le32`, `cpu_to_be64`, etc.).
+- Prefer explicit structure ownership/lifetime patterns already used (kref, RCU, locks).
+
+### Error Handling
+
+- Use kernel-style negative error codes (`-ENOMEM`, `-EINVAL`, etc.).
+- Check return values from allocations, crypto ops, and kernel APIs.
+- Use early returns and `goto` unwind labels for structured cleanup.
+- Keep cleanup labels ordered from most-specific failure to shared teardown.
+
+### Concurrency / Memory Safety
+
+- Preserve existing locking discipline (`spin_lock_bh`, `down_read`, `down_write`, RCU helpers).
+- Do not change lock ordering without strong justification.
+- Zero sensitive material with `memzero_explicit` / `kfree_sensitive` where applicable.
+- Use `READ_ONCE` / `WRITE_ONCE` patterns consistently with surrounding code.
+
+### Logging And Diagnostics
+
+- Use kernel logging macros (`pr_info`, `net_dbg_ratelimited`, etc.) already used in subsystem.
+- Keep logs concise and useful; avoid excessive noisy logs in hot paths.
+- Debug-only behavior should remain guarded by existing debug config paths.
+
+### Kbuild / Compatibility Updates
+
+- If adding/removing source files, update `src/Kbuild` object lists.
+- If kernel-version compatibility is affected, update `src/compat/Kbuild.include` and related compat headers/sources.
+- Do not break support assumptions for older kernels without explicit requirement.
+
+### Test Script Edits
+
+- `src/tests/netns.sh` is a strict `set -e` integration script; keep commands deterministic.
+- Keep privileged/network-mutating steps paired with cleanup logic.
+- For `src/tests/qemu/Makefile`, preserve cross-arch conditionals and existing variable conventions.
+
+## Repository-Specific Policy Files
+
+- Cursor rules:
+  - No `.cursor/rules/` directory found.
+  - No `.cursorrules` file found.
+- Copilot rules:
+  - No `.github/copilot-instructions.md` found.
+
+If these files are added later, update this document to reflect and enforce them.

--- a/src/cookie.c
+++ b/src/cookie.c
@@ -32,7 +32,7 @@ static void precompute_key(u8 key[NOISE_SYMMETRIC_KEY_LEN],
 			   const u8 pubkey[NOISE_PUBLIC_KEY_LEN],
 			   const u8 label[COOKIE_KEY_LABEL_LEN])
 {
-	struct blake2s_state blake;
+	struct wg_blake2s_state blake;
 
 	blake2s_init(&blake, NOISE_SYMMETRIC_KEY_LEN);
 	blake2s_update(&blake, label, COOKIE_KEY_LABEL_LEN);
@@ -76,7 +76,7 @@ static void compute_mac1(u8 mac1[COOKIE_LEN], const void *message, size_t len,
 {
 	len = len - sizeof(struct message_macs) +
 	      offsetof(struct message_macs, mac1);
-	blake2s(mac1, message, key, COOKIE_LEN, len, NOISE_SYMMETRIC_KEY_LEN);
+	wg_blake2s(mac1, message, key, COOKIE_LEN, len, NOISE_SYMMETRIC_KEY_LEN);
 }
 
 static void compute_mac2(u8 mac2[COOKIE_LEN], const void *message, size_t len,
@@ -84,13 +84,13 @@ static void compute_mac2(u8 mac2[COOKIE_LEN], const void *message, size_t len,
 {
 	len = len - sizeof(struct message_macs) +
 	      offsetof(struct message_macs, mac2);
-	blake2s(mac2, message, cookie, COOKIE_LEN, len, COOKIE_LEN);
+	wg_blake2s(mac2, message, cookie, COOKIE_LEN, len, COOKIE_LEN);
 }
 
 static void make_cookie(u8 cookie[COOKIE_LEN], struct sk_buff *skb,
 			struct cookie_checker *checker)
 {
-	struct blake2s_state state;
+	struct wg_blake2s_state state;
 
 	if (wg_birthdate_has_expired(checker->secret_birthdate,
 				     COOKIE_SECRET_MAX_AGE)) {

--- a/src/cookie.c
+++ b/src/cookie.c
@@ -10,7 +10,6 @@
 #include "ratelimiter.h"
 #include "timers.h"
 
-#include <crypto/blake2s.h>
 #include <crypto/chacha20poly1305.h>
 #include <crypto/utils.h>
 

--- a/src/messages.h
+++ b/src/messages.h
@@ -8,7 +8,7 @@
 
 #include <crypto/curve25519.h>
 #include <crypto/chacha20poly1305.h>
-#include <crypto/blake2s.h>
+#include "crypto/include/zinc/blake2s.h"
 
 #include <linux/kernel.h>
 #include <linux/param.h>

--- a/src/messages.h
+++ b/src/messages.h
@@ -22,6 +22,22 @@ enum noise_lengths {
 	NOISE_HASH_LEN = BLAKE2S_HASH_SIZE
 };
 
+#if COMPAT_VERSION > 6 || (COMPAT_VERSION == 6 && COMPAT_PATCHLEVEL >= 19)
+#define wg_blake2s_state blake2s_ctx
+static inline void wg_blake2s(u8 *out, const u8 *in, const u8 *key,
+			      size_t outlen, size_t inlen, size_t keylen)
+{
+	blake2s(key, keylen, in, inlen, out, outlen);
+}
+#else
+#define wg_blake2s_state blake2s_state
+static inline void wg_blake2s(u8 *out, const u8 *in, const u8 *key,
+			      size_t outlen, size_t inlen, size_t keylen)
+{
+	blake2s(out, in, key, outlen, inlen, keylen);
+}
+#endif
+
 #define noise_encrypted_len(plain_len) ((plain_len) + NOISE_AUTHTAG_LEN)
 
 enum cookie_values {

--- a/src/messages.h
+++ b/src/messages.h
@@ -8,7 +8,7 @@
 
 #include <crypto/curve25519.h>
 #include <crypto/chacha20poly1305.h>
-#include "crypto/include/zinc/blake2s.h"
+#include <crypto/blake2s.h>
 
 #include <linux/kernel.h>
 #include <linux/param.h>

--- a/src/netlink.c
+++ b/src/netlink.c
@@ -88,7 +88,10 @@ static struct wg_device *lookup_interface(struct nlattr **attrs,
 	struct net_device *dev = NULL;
 
 	if (!attrs[WGDEVICE_A_IFINDEX] == !attrs[WGDEVICE_A_IFNAME])
+	{
+		pr_err_ratelimited("amneziawg: lookup_interface invalid IFINDEX/IFNAME combination\n");
 		return ERR_PTR(-EBADR);
+	}
 	if (attrs[WGDEVICE_A_IFINDEX])
 		dev = dev_get_by_index(sock_net(skb->sk),
 				       nla_get_u32(attrs[WGDEVICE_A_IFINDEX]));
@@ -96,9 +99,15 @@ static struct wg_device *lookup_interface(struct nlattr **attrs,
 		dev = dev_get_by_name(sock_net(skb->sk),
 				      nla_data(attrs[WGDEVICE_A_IFNAME]));
 	if (!dev)
+	{
+		pr_err_ratelimited("amneziawg: lookup_interface device not found\n");
 		return ERR_PTR(-ENODEV);
+	}
 	if (!dev->rtnl_link_ops || !dev->rtnl_link_ops->kind ||
 	    strcmp(dev->rtnl_link_ops->kind, KBUILD_MODNAME)) {
+		pr_err_ratelimited("amneziawg: lookup_interface wrong link kind (expected %s, got %s)\n",
+				   KBUILD_MODNAME,
+				   dev->rtnl_link_ops && dev->rtnl_link_ops->kind ? dev->rtnl_link_ops->kind : "<none>");
 		dev_put(dev);
 		return ERR_PTR(-EOPNOTSUPP);
 	}
@@ -561,8 +570,10 @@ static int set_allowedip(struct wg_peer *peer, struct nlattr **attrs)
 	u8 cidr;
 
 	if (!attrs[WGALLOWEDIP_A_FAMILY] || !attrs[WGALLOWEDIP_A_IPADDR] ||
-	    !attrs[WGALLOWEDIP_A_CIDR_MASK])
+	    !attrs[WGALLOWEDIP_A_CIDR_MASK]) {
+		pr_err_ratelimited("amneziawg: set_allowedip missing required attributes\n");
 		return ret;
+	}
 	family = nla_get_u16(attrs[WGALLOWEDIP_A_FAMILY]);
 	cidr = nla_get_u8(attrs[WGALLOWEDIP_A_CIDR_MASK]);
 	if (attrs[WGALLOWEDIP_A_FLAGS])
@@ -588,6 +599,9 @@ static int set_allowedip(struct wg_peer *peer, struct nlattr **attrs)
 			ret = wg_allowedips_insert_v6(&peer->device->peer_allowedips,
 						      nla_data(attrs[WGALLOWEDIP_A_IPADDR]), cidr,
 						      peer, &peer->device->device_update_lock);
+	} else {
+		pr_err_ratelimited("amneziawg: set_allowedip invalid allowedip tuple (family=%u cidr=%u len=%u)\n",
+				   family, cidr, nla_len(attrs[WGALLOWEDIP_A_IPADDR]));
 	}
 
 	return ret;
@@ -604,8 +618,10 @@ static int set_peer(struct wg_device *wg, struct nlattr **attrs)
 	if (attrs[WGPEER_A_PUBLIC_KEY] &&
 	    nla_len(attrs[WGPEER_A_PUBLIC_KEY]) == NOISE_PUBLIC_KEY_LEN)
 		public_key = nla_data(attrs[WGPEER_A_PUBLIC_KEY]);
-	else
+	else {
+		pr_err_ratelimited("amneziawg: set_peer invalid or missing public key\n");
 		goto out;
+	}
 	if (attrs[WGPEER_A_PRESHARED_KEY] &&
 	    nla_len(attrs[WGPEER_A_PRESHARED_KEY]) == NOISE_SYMMETRIC_KEY_LEN)
 		preshared_key = nla_data(attrs[WGPEER_A_PRESHARED_KEY]);
@@ -615,8 +631,11 @@ static int set_peer(struct wg_device *wg, struct nlattr **attrs)
 
 	ret = -EPFNOSUPPORT;
 	if (attrs[WGPEER_A_PROTOCOL_VERSION]) {
-		if (nla_get_u32(attrs[WGPEER_A_PROTOCOL_VERSION]) != 1)
+		if (nla_get_u32(attrs[WGPEER_A_PROTOCOL_VERSION]) != 1) {
+			pr_err_ratelimited("amneziawg: set_peer unsupported protocol version %u\n",
+					   nla_get_u32(attrs[WGPEER_A_PROTOCOL_VERSION]));
 			goto out;
+		}
 	}
 
 	peer = wg_pubkey_hashtable_lookup(wg->peer_hashtable,
@@ -694,11 +713,17 @@ static int set_peer(struct wg_device *wg, struct nlattr **attrs)
 		nla_for_each_nested(attr, attrs[WGPEER_A_ALLOWEDIPS], rem) {
 			ret = nla_parse_nested(allowedip, WGALLOWEDIP_A_MAX,
 					       attr, allowedip_policy, NULL);
-			if (ret < 0)
+			if (ret < 0) {
+				pr_err_ratelimited("amneziawg: set_peer failed to parse allowedip nested attrs (%d)\n",
+						   ret);
 				goto out;
+			}
 			ret = set_allowedip(peer, allowedip);
-			if (ret < 0)
+			if (ret < 0) {
+				pr_err_ratelimited("amneziawg: set_peer failed to set allowedip (%d)\n",
+						   ret);
 				goto out;
+			}
 		}
 	}
 
@@ -716,6 +741,11 @@ static int set_peer(struct wg_device *wg, struct nlattr **attrs)
 	}
 
 	if (flags & WGPEER_F_HAS_ADVANCED_SECURITY) {
+		if (!attrs[WGPEER_A_ADVANCED_SECURITY]) {
+			pr_err_ratelimited("amneziawg: set_peer WGPEER_F_HAS_ADVANCED_SECURITY set without WGPEER_A_ADVANCED_SECURITY attribute\n");
+			ret = -EINVAL;
+			goto out;
+		}
 		peer->advanced_security = wg->advanced_security &&
 				nla_get_flag(attrs[WGPEER_A_ADVANCED_SECURITY]);
 	}
@@ -804,37 +834,61 @@ static int wg_set_device(struct sk_buff *skb, struct genl_info *info)
 	if (info->attrs[WGDEVICE_A_H1]) {
 		wg->advanced_security = true;
 		str = nla_strdup(info->attrs[WGDEVICE_A_H1], GFP_KERNEL);
+		if (!str) {
+			ret = -ENOMEM;
+			goto out;
+		}
 		ret = mh_parse(&wg->headers[MSGIDX_HANDSHAKE_INIT], str);
 		kfree(str);
-		if (ret)
+		if (ret) {
+			pr_err_ratelimited("amneziawg: invalid H1 descriptor\n");
 			goto out;
+		}
 	}
 
 	if (info->attrs[WGDEVICE_A_H2]) {
 		wg->advanced_security = true;
 		str = nla_strdup(info->attrs[WGDEVICE_A_H2], GFP_KERNEL);
+		if (!str) {
+			ret = -ENOMEM;
+			goto out;
+		}
 		ret = mh_parse(&wg->headers[MSGIDX_HANDSHAKE_RESPONSE], str);
 		kfree(str);
-		if (ret)
+		if (ret) {
+			pr_err_ratelimited("amneziawg: invalid H2 descriptor\n");
 			goto out;
+		}
 	}
 
 	if (info->attrs[WGDEVICE_A_H3]) {
 		wg->advanced_security = true;
 		str = nla_strdup(info->attrs[WGDEVICE_A_H3], GFP_KERNEL);
+		if (!str) {
+			ret = -ENOMEM;
+			goto out;
+		}
 		ret = mh_parse(&wg->headers[MSGIDX_HANDSHAKE_COOKIE], str);
 		kfree(str);
-		if (ret)
+		if (ret) {
+			pr_err_ratelimited("amneziawg: invalid H3 descriptor\n");
 			goto out;
+		}
 	}
 
 	if (info->attrs[WGDEVICE_A_H4]) {
 		wg->advanced_security = true;
 		str = nla_strdup(info->attrs[WGDEVICE_A_H4], GFP_KERNEL);
+		if (!str) {
+			ret = -ENOMEM;
+			goto out;
+		}
 		ret = mh_parse(&wg->headers[MSGIDX_TRANSPORT], str);
 		kfree(str);
-		if (ret)
+		if (ret) {
+			pr_err_ratelimited("amneziawg: invalid H4 descriptor\n");
 			goto out;
+		}
 	}
 
 	if (info->attrs[WGDEVICE_A_S3]) {
@@ -922,11 +976,16 @@ skip_set_private_key:
 		nla_for_each_nested(attr, info->attrs[WGDEVICE_A_PEERS], rem) {
 			ret = nla_parse_nested(peer, WGPEER_A_MAX, attr,
 					       peer_policy, NULL);
-			if (ret < 0)
+			if (ret < 0) {
+				pr_err_ratelimited("amneziawg: failed to parse peer nested attrs (%d)\n",
+						   ret);
 				goto out;
+			}
 			ret = set_peer(wg, peer);
-			if (ret < 0)
+			if (ret < 0) {
+				pr_err_ratelimited("amneziawg: failed to set peer (%d)\n", ret);
 				goto out;
+			}
 		}
 	}
 	ret = 0;
@@ -936,6 +995,8 @@ out:
 	rtnl_unlock();
 	dev_put(wg->dev);
 out_nodev:
+	if (ret)
+		pr_err_ratelimited("amneziawg: wg_set_device failed early (%d)\n", ret);
 	if (info->attrs[WGDEVICE_A_PRIVATE_KEY])
 		memzero_explicit(nla_data(info->attrs[WGDEVICE_A_PRIVATE_KEY]),
 				 nla_len(info->attrs[WGDEVICE_A_PRIVATE_KEY]));

--- a/src/noise.c
+++ b/src/noise.c
@@ -36,10 +36,10 @@ static atomic64_t keypair_counter = ATOMIC64_INIT(0);
 
 void __init wg_noise_init(void)
 {
-	struct blake2s_state blake;
+	struct wg_blake2s_state blake;
 
-	blake2s(handshake_init_chaining_key, handshake_name, NULL,
-		NOISE_HASH_LEN, sizeof(handshake_name), 0);
+	wg_blake2s(handshake_init_chaining_key, handshake_name, NULL,
+		   NOISE_HASH_LEN, sizeof(handshake_name), 0);
 	blake2s_init(&blake, NOISE_HASH_LEN);
 	blake2s_update(&blake, handshake_init_chaining_key, NOISE_HASH_LEN);
 	blake2s_update(&blake, identifier_name, sizeof(identifier_name));
@@ -307,7 +307,7 @@ void wg_noise_set_static_identity_private_key(
 
 static void hmac(u8 *out, const u8 *in, const u8 *key, const size_t inlen, const size_t keylen)
 {
-	struct blake2s_state state;
+	struct wg_blake2s_state state;
 	u8 x_key[BLAKE2S_BLOCK_SIZE] __aligned(__alignof__(u32)) = { 0 };
 	u8 i_hash[BLAKE2S_HASH_SIZE] __aligned(__alignof__(u32));
 	int i;
@@ -434,7 +434,7 @@ static bool __must_check mix_precomputed_dh(u8 chaining_key[NOISE_HASH_LEN],
 
 static void mix_hash(u8 hash[NOISE_HASH_LEN], const u8 *src, size_t src_len)
 {
-	struct blake2s_state blake;
+	struct wg_blake2s_state blake;
 
 	blake2s_init(&blake, NOISE_HASH_LEN);
 	blake2s_update(&blake, hash, NOISE_HASH_LEN);


### PR DESCRIPTION
## Summary
- Add a BLAKE2s compatibility wrapper so the module builds against both pre-6.19 and 6.19+ kernel APIs.
- Update noise/cookie hashing call sites in noise/cookie paths to use the compatibility wrapper and avoid type/signature breakage.
- Add targeted netlink error logs to make `Unable to modify interface: Invalid argument` failures diagnosable in dmesg.