### PR TITLE
Revert "compat: fix compilation on kernels >= 6.19 (blake2s API change)"

### DIFF
--- a/src/compat/compat.h
+++ b/src/compat/compat.h
@@ -1399,12 +1399,4 @@ static inline char *nla_strdup(const struct nlattr *nla, gfp_t flags)
 #define COMPAT_CANNOT_USE_NETLINK_MCGRPS
 #endif
 
-/* Kernel 6.19+ renamed blake2s_state to blake2s_ctx and changed blake2s() arg order */
-#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 19, 0)
-#include <crypto/blake2s.h>
-#define blake2s_ctx blake2s_state
-#define blake2s(key, keylen, in, inlen, out, outlen) \
-	blake2s(out, in, key, outlen, inlen, keylen)
-#endif
-
 #endif /* _WG_COMPAT_H */

--- a/src/cookie.c
+++ b/src/cookie.c
@@ -33,7 +33,7 @@ static void precompute_key(u8 key[NOISE_SYMMETRIC_KEY_LEN],
 			   const u8 pubkey[NOISE_PUBLIC_KEY_LEN],
 			   const u8 label[COOKIE_KEY_LABEL_LEN])
 {
-	struct blake2s_ctx blake;
+	struct blake2s_state blake;
 
 	blake2s_init(&blake, NOISE_SYMMETRIC_KEY_LEN);
 	blake2s_update(&blake, label, COOKIE_KEY_LABEL_LEN);
@@ -77,7 +77,7 @@ static void compute_mac1(u8 mac1[COOKIE_LEN], const void *message, size_t len,
 {
 	len = len - sizeof(struct message_macs) +
 	      offsetof(struct message_macs, mac1);
-	blake2s(key, NOISE_SYMMETRIC_KEY_LEN, message, len, mac1, COOKIE_LEN);
+	blake2s(mac1, message, key, COOKIE_LEN, len, NOISE_SYMMETRIC_KEY_LEN);
 }
 
 static void compute_mac2(u8 mac2[COOKIE_LEN], const void *message, size_t len,
@@ -85,13 +85,13 @@ static void compute_mac2(u8 mac2[COOKIE_LEN], const void *message, size_t len,
 {
 	len = len - sizeof(struct message_macs) +
 	      offsetof(struct message_macs, mac2);
-	blake2s(cookie, COOKIE_LEN, message, len, mac2, COOKIE_LEN);
+	blake2s(mac2, message, cookie, COOKIE_LEN, len, COOKIE_LEN);
 }
 
 static void make_cookie(u8 cookie[COOKIE_LEN], struct sk_buff *skb,
 			struct cookie_checker *checker)
 {
-	struct blake2s_ctx state;
+	struct blake2s_state state;
 
 	if (wg_birthdate_has_expired(checker->secret_birthdate,
 				     COOKIE_SECRET_MAX_AGE)) {

--- a/src/noise.c
+++ b/src/noise.c
@@ -36,10 +36,10 @@ static atomic64_t keypair_counter = ATOMIC64_INIT(0);
 
 void __init wg_noise_init(void)
 {
-	struct blake2s_ctx blake;
+	struct blake2s_state blake;
 
-	blake2s(NULL, 0, handshake_name, sizeof(handshake_name),
-		handshake_init_chaining_key, NOISE_HASH_LEN);
+	blake2s(handshake_init_chaining_key, handshake_name, NULL,
+		NOISE_HASH_LEN, sizeof(handshake_name), 0);
 	blake2s_init(&blake, NOISE_HASH_LEN);
 	blake2s_update(&blake, handshake_init_chaining_key, NOISE_HASH_LEN);
 	blake2s_update(&blake, identifier_name, sizeof(identifier_name));
@@ -307,7 +307,7 @@ void wg_noise_set_static_identity_private_key(
 
 static void hmac(u8 *out, const u8 *in, const u8 *key, const size_t inlen, const size_t keylen)
 {
-	struct blake2s_ctx state;
+	struct blake2s_state state;
 	u8 x_key[BLAKE2S_BLOCK_SIZE] __aligned(__alignof__(u32)) = { 0 };
 	u8 i_hash[BLAKE2S_HASH_SIZE] __aligned(__alignof__(u32));
 	int i;
@@ -434,7 +434,7 @@ static bool __must_check mix_precomputed_dh(u8 chaining_key[NOISE_HASH_LEN],
 
 static void mix_hash(u8 hash[NOISE_HASH_LEN], const u8 *src, size_t src_len)
 {
-	struct blake2s_ctx blake;
+	struct blake2s_state blake;
 
 	blake2s_init(&blake, NOISE_HASH_LEN);
 	blake2s_update(&blake, hash, NOISE_HASH_LEN);


### PR DESCRIPTION
Reverts amnezia-vpn/amneziawg-linux-kernel-module#145

Compilation issues in Ubuntu 20.04

```
  CC [M]  /var/lib/dkms/amneziawg/1.0.0/build/crypto/zinc/blake2s/blake2s.o
In file included from /var/lib/dkms/amneziawg/1.0.0/build/crypto/zinc/blake2s/blake2s.c:11:
/var/lib/dkms/amneziawg/1.0.0/build/crypto/include/zinc/blake2s.h:13:6: error: nested redefinition of 'enum blake2s_lengths'
   13 | enum blake2s_lengths {
      |      ^~~~~~~~~~~~~~~
/var/lib/dkms/amneziawg/1.0.0/build/crypto/include/zinc/blake2s.h:13:6: error: redeclaration of 'enum blake2s_lengths'
In file included from /var/lib/dkms/amneziawg/1.0.0/build/compat/compat.h:1404,
                 from <command-line>:
./include/crypto/blake2s.h:14:6: note: originally defined here
   14 | enum blake2s_lengths {
      |      ^~~~~~~~~~~~~~~
In file included from /var/lib/dkms/amneziawg/1.0.0/build/crypto/zinc/blake2s/blake2s.c:11:
/var/lib/dkms/amneziawg/1.0.0/build/crypto/include/zinc/blake2s.h:14:2: error: redeclaration of enumerator 'BLAKE2S_BLOCK_SIZE'
   14 |  BLAKE2S_BLOCK_SIZE = 64,
      |  ^~~~~~~~~~~~~~~~~~
In file included from /var/lib/dkms/amneziawg/1.0.0/build/compat/compat.h:1404,
                 from <command-line>:
./include/crypto/blake2s.h:15:2: note: previous definition of 'BLAKE2S_BLOCK_SIZE' was here
   15 |  BLAKE2S_BLOCK_SIZE = 64,
      |  ^~~~~~~~~~~~~~~~~~
In file included from /var/lib/dkms/amneziawg/1.0.0/build/crypto/zinc/blake2s/blake2s.c:11:
/var/lib/dkms/amneziawg/1.0.0/build/crypto/include/zinc/blake2s.h:15:2: error: redeclaration of enumerator 'BLAKE2S_HASH_SIZE'
   15 |  BLAKE2S_HASH_SIZE = 32,
      |  ^~~~~~~~~~~~~~~~~
In file included from /var/lib/dkms/amneziawg/1.0.0/build/compat/compat.h:1404,
                 from <command-line>:
./include/crypto/blake2s.h:16:2: note: previous definition of 'BLAKE2S_HASH_SIZE' was here
   16 |  BLAKE2S_HASH_SIZE = 32,
./include/crypto/blake2s.h:16:2: note: previous definition of 'BLAKE2S_HASH_SIZE' was here
   16 |  BLAKE2S_HASH_SIZE = 32,
      |  ^~~~~~~~~~~~~~~~~
In file included from /var/lib/dkms/amneziawg/1.0.0/build/crypto/zinc/blake2s/blake2s.c:11:
/var/lib/dkms/amneziawg/1.0.0/build/crypto/include/zinc/blake2s.h:16:2: error: redeclaration of enumerator 'BLAKE2S_KEY_SIZE'
   16 |  BLAKE2S_KEY_SIZE = 32
      |  ^~~~~~~~~~~~~~~~
In file included from /var/lib/dkms/amneziawg/1.0.0/build/compat/compat.h:1404,
                 from <command-line>:
./include/crypto/blake2s.h:17:2: note: previous definition of 'BLAKE2S_KEY_SIZE' was here
   17 |  BLAKE2S_KEY_SIZE = 32,
      |  ^~~~~~~~~~~~~~~~
In file included from /var/lib/dkms/amneziawg/1.0.0/build/crypto/zinc/blake2s/blake2s.c:11:
/var/lib/dkms/amneziawg/1.0.0/build/crypto/include/zinc/blake2s.h:19:8: error: redefinition of 'struct blake2s_state'
   19 | struct blake2s_state {
      |        ^~~~~~~~~~~~~
In file included from /var/lib/dkms/amneziawg/1.0.0/build/compat/compat.h:1404,
                 from <command-line>:
./include/crypto/blake2s.h:25:8: note: originally defined here
   25 | struct blake2s_state {
      |        ^~~~~~~~~~~~~
In file included from /var/lib/dkms/amneziawg/1.0.0/build/crypto/zinc/blake2s/blake2s.c:11:
/var/lib/dkms/amneziawg/1.0.0/build/crypto/include/zinc/blake2s.h:28:6: error: conflicting types for 'blake2s_init'
   28 | void blake2s_init(struct blake2s_state *state, const size_t outlen);
      |      ^~~~~~~~~~~~
In file included from /var/lib/dkms/amneziawg/1.0.0/build/compat/compat.h:1404,
                 from <command-line>:
./include/crypto/blake2s.h:63:20: note: previous definition of 'blake2s_init' was here
   63 | static inline void blake2s_init(struct blake2s_state *state,
      |                    ^~~~~~~~~~~~
In file included from /var/lib/dkms/amneziawg/1.0.0/build/crypto/zinc/blake2s/blake2s.c:11:
/var/lib/dkms/amneziawg/1.0.0/build/crypto/include/zinc/blake2s.h:29:6: error: conflicting types for 'blake2s_init_key'
   29 | void blake2s_init_key(struct blake2s_state *state, const size_t outlen,
      |      ^~~~~~~~~~~~~~~~
In file included from /var/lib/dkms/amneziawg/1.0.0/build/compat/compat.h:1404,
                 from <command-line>:
./include/crypto/blake2s.h:70:20: note: previous definition of 'blake2s_init_key' was here
   70 | static inline void blake2s_init_key(struct blake2s_state *state,
      |                    ^~~~~~~~~~~~~~~~
In file included from /var/lib/dkms/amneziawg/1.0.0/build/crypto/zinc/blake2s/blake2s.c:11:
/var/lib/dkms/amneziawg/1.0.0/build/crypto/include/zinc/blake2s.h:31:6: error: conflicting types for 'blake2s_update'
   31 | void blake2s_update(struct blake2s_state *state, const u8 *in, size_t inlen);
      |      ^~~~~~~~~~~~~~
In file included from /var/lib/dkms/amneziawg/1.0.0/build/compat/compat.h:1404,
                 from <command-line>:
./include/crypto/blake2s.h:45:6: note: previous declaration of 'blake2s_update' was here
   45 | void blake2s_update(struct blake2s_state *state, const u8 *in, size_t inlen);
      |      ^~~~~~~~~~~~~~
In file included from /var/lib/dkms/amneziawg/1.0.0/build/crypto/zinc/blake2s/blake2s.c:11:
/var/lib/dkms/amneziawg/1.0.0/build/crypto/include/zinc/blake2s.h:32:6: error: conflicting types for 'blake2s_final'
   32 | void blake2s_final(struct blake2s_state *state, u8 *out);
      |      ^~~~~~~~~~~~~
In file included from /var/lib/dkms/amneziawg/1.0.0/build/compat/compat.h:1404,
      |      ^~~~~~~~~~~~~
In file included from /var/lib/dkms/amneziawg/1.0.0/build/compat/compat.h:1404,
                 from <command-line>:
./include/crypto/blake2s.h:46:6: note: previous declaration of 'blake2s_final' was here
   46 | void blake2s_final(struct blake2s_state *state, u8 *out);
      |      ^~~~~~~~~~~~~
In file included from <command-line>:
/var/lib/dkms/amneziawg/1.0.0/build/compat/compat.h:1407:2: error: conflicting types for 'blake2s'
 1407 |  blake2s(out, in, key, outlen, inlen, keylen)
      |  ^~~~~~~
/var/lib/dkms/amneziawg/1.0.0/build/crypto/include/zinc/blake2s.h:34:20: note: in expansion of macro 'blake2s'
   34 | static inline void blake2s(u8 *out, const u8 *in, const u8 *key,
      |                    ^~~~~~~
In file included from /var/lib/dkms/amneziawg/1.0.0/build/compat/compat.h:1404,
                 from <command-line>:
./include/crypto/blake2s.h:83:20: note: previous definition of 'blake2s' was here
   83 | static inline void blake2s(u8 *out, const u8 *in, const u8 *key,
      |                    ^~~~~~~
/var/lib/dkms/amneziawg/1.0.0/build/crypto/zinc/blake2s/blake2s.c:52:20: error: conflicting types for 'blake2s_init_param'
   52 | static inline void blake2s_init_param(struct blake2s_state *state,
      |                    ^~~~~~~~~~~~~~~~~~
In file included from /var/lib/dkms/amneziawg/1.0.0/build/compat/compat.h:1404,
                 from <command-line>:
./include/crypto/blake2s.h:48:20: note: previous definition of 'blake2s_init_param' was here
   48 | static inline void blake2s_init_param(struct blake2s_state *state,
      |                    ^~~~~~~~~~~~~~~~~~
/var/lib/dkms/amneziawg/1.0.0/build/crypto/zinc/blake2s/blake2s.c:170:6: error: conflicting types for 'blake2s_update'
  170 | void blake2s_update(struct blake2s_state *state, const u8 *in, size_t inlen)
      |      ^~~~~~~~~~~~~~
In file included from /var/lib/dkms/amneziawg/1.0.0/build/compat/compat.h:1404,
                 from <command-line>:
./include/crypto/blake2s.h:45:6: note: previous declaration of 'blake2s_update' was here
   45 | void blake2s_update(struct blake2s_state *state, const u8 *in, size_t inlen);
      |      ^~~~~~~~~~~~~~
/var/lib/dkms/amneziawg/1.0.0/build/crypto/zinc/blake2s/blake2s.c:194:6: error: conflicting types for 'blake2s_final'
  194 | void blake2s_final(struct blake2s_state *state, u8 *out)
      |      ^~~~~~~~~~~~~
In file included from /var/lib/dkms/amneziawg/1.0.0/build/compat/compat.h:1404,
                 from <command-line>:
./include/crypto/blake2s.h:46:6: note: previous declaration of 'blake2s_final' was here
   46 | void blake2s_final(struct blake2s_state *state, u8 *out);
      |      ^~~~~~~~~~~~~
make[1]: *** [scripts/Makefile.build:270: /var/lib/dkms/amneziawg/1.0.0/build/crypto/zinc/blake2s/blake2s.o] Error 1

```