### PR TITLE
fix(compat): resolve blake2s regression from 26f5df0 on Ubuntu 20.04 (Kernel 5.4)

### DIFF
--- a/src/compat/compat.h
+++ b/src/compat/compat.h
@@ -1401,10 +1401,16 @@ static inline char *nla_strdup(const struct nlattr *nla, gfp_t flags)
 
 /* Kernel 6.19+ renamed blake2s_state to blake2s_ctx and changed blake2s() arg order */
 #if LINUX_VERSION_CODE < KERNEL_VERSION(6, 19, 0)
-#include <crypto/blake2s.h>
-#define blake2s_ctx blake2s_state
-#define blake2s(key, keylen, in, inlen, out, outlen) \
-	blake2s(out, in, key, outlen, inlen, keylen)
+    #if defined(ISUBUNTU2004)
+        #include "../crypto/include/zinc/blake2s.h"
+        #define _CRYPTO_BLAKE2S_H
+    #else
+        #include <crypto/blake2s.h>
+    #endif
+
+    #define blake2s_ctx blake2s_state
+    #define blake2s(key, keylen, in, inlen, out, outlen) \
+            (blake2s)((u8 *)(out), (const u8 *)(in), (const u8 *)(key), (size_t)(outlen), (size_t)(inlen), (size_t)(keylen))
 #endif
 
 #endif /* _WG_COMPAT_H */


### PR DESCRIPTION
Fixes #158

Fixes a regression for older kernels (specifically 5.4 on Ubuntu 20.04) introduced in commit 26f5df0.

Commit [26f5df0] updated the blake2s API to support kernels ≥ 6.19 by renaming the context and swapping argument order. However, this caused a regression on older distributions like Ubuntu 20.04, where:

Including system headers leads to symbol collisions with internal Zinc code.

The kernel still expects the legacy argument order for blake2s().