### PR TITLE
fix: restore per-peer legacy WireGuard client support

### DIFF
--- a/src/receive.c
+++ b/src/receive.c
@@ -67,6 +67,20 @@ static size_t prepare_awg_message(struct sk_buff *skb, struct wg_device *wg)
 			skb_push(skb, wg->junk_size[MSGIDX_TRANSPORT]);
 	}
 
+	/* Legacy WireGuard client support: accept standard packets */
+	if (skb->len == MESSAGE_INITIATION_SIZE &&
+	    SKB_TYPE_LE32(skb) == cpu_to_le32(MESSAGE_HANDSHAKE_INITIATION))
+		return MESSAGE_INITIATION_SIZE;
+	if (skb->len == MESSAGE_RESPONSE_SIZE &&
+	    SKB_TYPE_LE32(skb) == cpu_to_le32(MESSAGE_HANDSHAKE_RESPONSE))
+		return MESSAGE_RESPONSE_SIZE;
+	if (skb->len == MESSAGE_COOKIE_REPLY_SIZE &&
+	    SKB_TYPE_LE32(skb) == cpu_to_le32(MESSAGE_HANDSHAKE_COOKIE))
+		return MESSAGE_COOKIE_REPLY_SIZE;
+	if (skb->len >= MESSAGE_MINIMUM_LENGTH &&
+	    SKB_TYPE_LE32(skb) == cpu_to_le32(MESSAGE_DATA))
+		return MESSAGE_TRANSPORT_SIZE;
+
 	net_dbg_skb_ratelimited("%s: Unknown message from %pISpfsc encountered, packet dropped\n",
 								wg->dev->name, skb);
 
@@ -130,7 +144,8 @@ static void wg_receive_handshake_packet(struct wg_device *wg,
 	bool packet_needs_cookie;
 	bool under_load;
 
-	if (mh_validate(SKB_TYPE_LE32(skb), &wg->headers[MSGIDX_HANDSHAKE_COOKIE])) {
+	if (mh_validate(SKB_TYPE_LE32(skb), &wg->headers[MSGIDX_HANDSHAKE_COOKIE]) ||
+	    SKB_TYPE_LE32(skb) == cpu_to_le32(MESSAGE_HANDSHAKE_COOKIE)) {
 		net_dbg_skb_ratelimited("%s: Receiving cookie response from %pISpfsc\n",
 					wg->dev->name, skb);
 		wg_cookie_message_consume(
@@ -160,7 +175,8 @@ static void wg_receive_handshake_packet(struct wg_device *wg,
 		return;
 	}
 
-	if (mh_validate(SKB_TYPE_LE32(skb), &wg->headers[MSGIDX_HANDSHAKE_INIT])) {
+	if (mh_validate(SKB_TYPE_LE32(skb), &wg->headers[MSGIDX_HANDSHAKE_INIT]) ||
+	    SKB_TYPE_LE32(skb) == cpu_to_le32(MESSAGE_HANDSHAKE_INITIATION)) {
 		struct message_handshake_initiation *message =
 			(struct message_handshake_initiation *)skb->data;
 
@@ -181,7 +197,8 @@ static void wg_receive_handshake_packet(struct wg_device *wg,
 				    &peer->endpoint.addr);
 		wg_packet_send_handshake_response(peer);
 	}
-	if (mh_validate(SKB_TYPE_LE32(skb), &wg->headers[MSGIDX_HANDSHAKE_RESPONSE])) {
+	if (mh_validate(SKB_TYPE_LE32(skb), &wg->headers[MSGIDX_HANDSHAKE_RESPONSE]) ||
+	    SKB_TYPE_LE32(skb) == cpu_to_le32(MESSAGE_HANDSHAKE_RESPONSE)) {
 		struct message_handshake_response *message =
 			(struct message_handshake_response *)skb->data;
 
@@ -585,8 +602,11 @@ void wg_packet_receive(struct wg_device *wg, struct sk_buff *skb)
 		goto err;
 
 	if (mh_validate(SKB_TYPE_LE32(skb), &wg->headers[MSGIDX_HANDSHAKE_INIT]) ||
-		mh_validate(SKB_TYPE_LE32(skb), &wg->headers[MSGIDX_HANDSHAKE_RESPONSE]) ||
-		mh_validate(SKB_TYPE_LE32(skb), &wg->headers[MSGIDX_HANDSHAKE_COOKIE])) {
+	    mh_validate(SKB_TYPE_LE32(skb), &wg->headers[MSGIDX_HANDSHAKE_RESPONSE]) ||
+	    mh_validate(SKB_TYPE_LE32(skb), &wg->headers[MSGIDX_HANDSHAKE_COOKIE]) ||
+	    SKB_TYPE_LE32(skb) == cpu_to_le32(MESSAGE_HANDSHAKE_INITIATION) ||
+	    SKB_TYPE_LE32(skb) == cpu_to_le32(MESSAGE_HANDSHAKE_RESPONSE) ||
+	    SKB_TYPE_LE32(skb) == cpu_to_le32(MESSAGE_HANDSHAKE_COOKIE)) {
 		int cpu, ret = -EBUSY;
 
 		if (unlikely(!rng_is_initialized()))
@@ -609,7 +629,8 @@ void wg_packet_receive(struct wg_device *wg, struct sk_buff *skb)
 		/* Queues up a call to packet_process_queued_handshake_packets(skb): */
 		queue_work_on(cpu, wg->handshake_receive_wq,
 			      &per_cpu_ptr(wg->handshake_queue.worker, cpu)->work);
-	} else if (mh_validate(SKB_TYPE_LE32(skb), &wg->headers[MSGIDX_TRANSPORT])) {
+	} else if (mh_validate(SKB_TYPE_LE32(skb), &wg->headers[MSGIDX_TRANSPORT]) ||
+		   SKB_TYPE_LE32(skb) == cpu_to_le32(MESSAGE_DATA)) {
 		PACKET_CB(skb)->ds = ip_tunnel_get_dsfield(ip_hdr(skb), skb);
 		wg_packet_consume_data(wg, skb);
 	} else {

--- a/src/send.c
+++ b/src/send.c
@@ -43,46 +43,52 @@ static void wg_packet_send_handshake_initiation(struct wg_peer *peer)
 			    peer->device->dev->name, peer->internal_id,
 			    &peer->endpoint.addr);
 
-	atomic_set(&peer->jp_packet_counter, get_random_u32());
-	for (i = 0; i < ARRAY_SIZE(wg->ispecs); ++i)
-	{
-		spec = &wg->ispecs[i];
-		if (spec->pkt_size > 0) {
-			mutex_lock(&spec->lock);
-			jp_spec_applymods(spec, peer);
-			wg_socket_send_buffer_to_peer(peer, spec->pkt, spec->pkt_size, 0, 0);
-			atomic_inc(&peer->jp_packet_counter);
-			mutex_unlock(&spec->lock);
-		}
-	}
-	
-	if (wg->jc && wg->jmax) {
-		net_dbg_ratelimited("%s: Sending dummy junk packets to %llu (%pISpfsc)\n",
-			    peer->device->dev->name, peer->internal_id,
-			    &peer->endpoint.addr);
-
-		junk_packet_count = wg->jc;
-		buffer = kzalloc(wg->jmax, GFP_KERNEL);
-
-		while (junk_packet_count-- > 0) {
-			junk_packet_size = (u16) get_random_u32_inclusive(wg->jmin, wg->jmax);
-
-			get_random_bytes(buffer, junk_packet_size);
-			get_random_bytes(&ds, 1);
-			wg_socket_send_buffer_to_peer(peer, buffer, junk_packet_size, ds, 0);
+	if (peer->advanced_security) {
+		atomic_set(&peer->jp_packet_counter, get_random_u32());
+		for (i = 0; i < ARRAY_SIZE(wg->ispecs); ++i) {
+			spec = &wg->ispecs[i];
+			if (spec->pkt_size > 0) {
+				mutex_lock(&spec->lock);
+				jp_spec_applymods(spec, peer);
+				wg_socket_send_buffer_to_peer(peer, spec->pkt, spec->pkt_size, 0, 0);
+				atomic_inc(&peer->jp_packet_counter);
+				mutex_unlock(&spec->lock);
+			}
 		}
 
-		kfree(buffer);
+		if (wg->jc && wg->jmax) {
+			net_dbg_ratelimited("%s: Sending dummy junk packets to %llu (%pISpfsc)\n",
+					    peer->device->dev->name, peer->internal_id,
+					    &peer->endpoint.addr);
+
+			junk_packet_count = wg->jc;
+			buffer = kzalloc(wg->jmax, GFP_KERNEL);
+
+			while (junk_packet_count-- > 0) {
+				junk_packet_size = (u16) get_random_u32_inclusive(wg->jmin, wg->jmax);
+
+				get_random_bytes(buffer, junk_packet_size);
+				get_random_bytes(&ds, 1);
+				wg_socket_send_buffer_to_peer(peer, buffer, junk_packet_size, ds, 0);
+			}
+
+			kfree(buffer);
+		}
 	}
 
-	if (wg_noise_handshake_create_initiation(&packet, &peer->handshake, mh_genheader(&wg->headers[MSGIDX_HANDSHAKE_INIT]))) {
+	if (wg_noise_handshake_create_initiation(&packet, &peer->handshake,
+			peer->advanced_security ?
+			mh_genheader(&wg->headers[MSGIDX_HANDSHAKE_INIT]) :
+			MESSAGE_HANDSHAKE_INITIATION)) {
 		wg_cookie_add_mac_to_packet(&packet, sizeof(packet), peer);
 		wg_timers_any_authenticated_packet_traversal(peer);
 		wg_timers_any_authenticated_packet_sent(peer);
 		atomic64_set(&peer->last_sent_handshake,
 			     ktime_get_coarse_boottime_ns());
 		wg_socket_send_buffer_to_peer(peer, &packet, sizeof(packet),
-					      HANDSHAKE_DSCP, wg->junk_size[MSGIDX_HANDSHAKE_INIT]);
+					      HANDSHAKE_DSCP,
+					      peer->advanced_security ?
+					      wg->junk_size[MSGIDX_HANDSHAKE_INIT] : 0);
 		wg_timers_handshake_initiated(peer);
 	}
 }
@@ -136,7 +142,10 @@ void wg_packet_send_handshake_response(struct wg_peer *peer)
 			    peer->device->dev->name, peer->internal_id,
 			    &peer->endpoint.addr);
 
-	if (wg_noise_handshake_create_response(&packet, &peer->handshake, mh_genheader(&wg->headers[MSGIDX_HANDSHAKE_RESPONSE]))) {
+	if (wg_noise_handshake_create_response(&packet, &peer->handshake,
+			peer->advanced_security ?
+			mh_genheader(&wg->headers[MSGIDX_HANDSHAKE_RESPONSE]) :
+			MESSAGE_HANDSHAKE_RESPONSE)) {
 		wg_cookie_add_mac_to_packet(&packet, sizeof(packet), peer);
 		if (wg_noise_handshake_begin_session(&peer->handshake,
 						     &peer->keypairs)) {
@@ -148,7 +157,8 @@ void wg_packet_send_handshake_response(struct wg_peer *peer)
 			wg_socket_send_buffer_to_peer(peer, &packet,
 						      sizeof(packet),
 						      HANDSHAKE_DSCP,
-							  wg->junk_size[MSGIDX_HANDSHAKE_RESPONSE]);
+						      peer->advanced_security ?
+						      wg->junk_size[MSGIDX_HANDSHAKE_RESPONSE] : 0);
 		}
 	}
 }
@@ -161,12 +171,21 @@ void wg_packet_send_handshake_cookie(struct wg_device *wg,
 
 	net_dbg_skb_ratelimited("%s: Sending cookie response for denied handshake message for %pISpfsc\n",
 				wg->dev->name, initiating_skb);
-	wg_cookie_message_create(&packet, initiating_skb, sender_index,
-				 &wg->cookie_checker,
-				 mh_genheader(&wg->headers[MSGIDX_HANDSHAKE_COOKIE]));
-	wg_socket_send_buffer_as_reply_to_skb(wg, initiating_skb, &packet,
-					      sizeof(packet),
-						  wg->junk_size[MSGIDX_HANDSHAKE_COOKIE]);
+	if (SKB_TYPE_LE32(initiating_skb) == cpu_to_le32(MESSAGE_HANDSHAKE_INITIATION) ||
+	    SKB_TYPE_LE32(initiating_skb) == cpu_to_le32(MESSAGE_HANDSHAKE_RESPONSE)) {
+		wg_cookie_message_create(&packet, initiating_skb, sender_index,
+					 &wg->cookie_checker,
+					 MESSAGE_HANDSHAKE_COOKIE);
+		wg_socket_send_buffer_as_reply_to_skb(wg, initiating_skb,
+						      &packet, sizeof(packet), 0);
+	} else {
+		wg_cookie_message_create(&packet, initiating_skb, sender_index,
+					 &wg->cookie_checker,
+					 mh_genheader(&wg->headers[MSGIDX_HANDSHAKE_COOKIE]));
+		wg_socket_send_buffer_as_reply_to_skb(wg, initiating_skb,
+						      &packet, sizeof(packet),
+						      wg->junk_size[MSGIDX_HANDSHAKE_COOKIE]);
+	}
 }
 
 static void keep_key_fresh(struct wg_peer *peer)
@@ -354,8 +373,11 @@ void wg_packet_encrypt_worker(struct work_struct *work)
 			wg = PACKET_PEER(first)->device;
 
 			if (likely(encrypt_packet(
-						  mh_genheader(&wg->headers[MSGIDX_TRANSPORT]),
-						  wg->junk_size[MSGIDX_TRANSPORT],
+						  PACKET_PEER(first)->advanced_security ?
+						  mh_genheader(&wg->headers[MSGIDX_TRANSPORT]) :
+						  MESSAGE_DATA,
+						  PACKET_PEER(first)->advanced_security ?
+						  wg->junk_size[MSGIDX_TRANSPORT] : 0,
 						  skb,
 						  PACKET_CB(first)->keypair
 						  COMPAT_MAYBE_SIMD_CONTEXT(&simd_context)))) {


### PR DESCRIPTION
## Summary

Restores the per-peer `advanced_security` checks in send and receive paths that were removed by commit e939553 ("feat: implement H1-H4 ranged headers"). This re-enables mixed-mode operation where an AmneziaWG server can simultaneously serve both standard WireGuard and AmneziaWG clients, as originally introduced in PR #16.

- Gate I-spec and junk packet sending on `peer->advanced_security`
- Use standard WG message types for legacy peers, custom `mh_genheader()` headers for AWG peers
- Skip junk padding for legacy peers
- Cookie responses match the header type of the incoming packet
- Add fallback in `prepare_awg_message()` to accept standard WireGuard packets
- Add standard WG message type checks in packet dispatch

The auto-detection in `noise.c` (which sets `peer->advanced_security` based on whether the incoming handshake used a custom magic header) was already correct and is unchanged.

## Test plan

- [x] Legacy WireGuard client connects to AWG server with custom H1-H4/S1-S2
- [x] AmneziaWG 2.0 client connects to AWG server with ranged H1-H4
- [x] AWG server with no custom parameters works as standard WireGuard

Closes #162