### PR TITLE
fix: detect AWG 1.0 vs 2.0 peers for header generation

### DIFF
--- a/src/magic_header.h
+++ b/src/magic_header.h
@@ -14,4 +14,13 @@ int mh_genspec(struct magic_header *mh, char *desc, size_t buflen);
 bool mh_validate(__le32 received, struct magic_header* mh);
 u32 mh_genheader(struct magic_header* mh);
 
+/* Generate a header appropriate for the peer's capability level.
+ * Ranged peers get a random value from the range (AWG 2.0).
+ * Fixed peers get the range start value (AWG 1.0 compatibility).
+ */
+static inline u32 mh_peerheader(struct magic_header *mh, bool ranged)
+{
+	return ranged ? mh_genheader(mh) : mh->start;
+}
+
 #endif

--- a/src/netlink.c
+++ b/src/netlink.c
@@ -72,7 +72,8 @@ static const struct nla_policy peer_policy[WGPEER_A_MAX + 1] = {
 	[WGPEER_A_TX_BYTES]				= { .type = NLA_U64 },
 	[WGPEER_A_ALLOWEDIPS]				= { .type = NLA_NESTED },
 	[WGPEER_A_PROTOCOL_VERSION]			= { .type = NLA_U32 },
-	[WGPEER_A_ADVANCED_SECURITY]    		= { .type = NLA_FLAG }
+	[WGPEER_A_ADVANCED_SECURITY]    		= { .type = NLA_FLAG },
+	[WGPEER_A_RANGED_HEADERS]			= { .type = NLA_FLAG }
 };
 
 static const struct nla_policy allowedip_policy[WGALLOWEDIP_A_MAX + 1] = {
@@ -297,6 +298,11 @@ get_peer(struct wg_peer *peer, struct sk_buff *skb, struct dump_ctx *ctx)
 		fail = nla_put_flag(skb, WGPEER_A_ADVANCED_SECURITY);
 		if (fail)
 			goto err;
+		if (peer->ranged_headers) {
+			fail = nla_put_flag(skb, WGPEER_A_RANGED_HEADERS);
+			if (fail)
+				goto err;
+		}
 	}
 
 	down_read(&peer->handshake.lock);
@@ -718,6 +724,16 @@ static int set_peer(struct wg_device *wg, struct nlattr **attrs)
 	if (flags & WGPEER_F_HAS_ADVANCED_SECURITY) {
 		peer->advanced_security = wg->advanced_security &&
 				nla_get_flag(attrs[WGPEER_A_ADVANCED_SECURITY]);
+		if (attrs[WGPEER_A_RANGED_HEADERS])
+			peer->ranged_headers = peer->advanced_security &&
+				nla_get_flag(attrs[WGPEER_A_RANGED_HEADERS]);
+		else
+			/* Default based on whether device uses ranges.
+			 * Will be auto-corrected on first incoming handshake.
+			 */
+			peer->ranged_headers = peer->advanced_security &&
+				(wg->headers[MSGIDX_HANDSHAKE_INIT].start !=
+				 wg->headers[MSGIDX_HANDSHAKE_INIT].end);
 	}
 
 	if (netif_running(wg->dev))
@@ -1016,7 +1032,8 @@ void __exit wg_genetlink_uninit(void)
 }
 
 int wg_genl_mcast_peer_unknown(struct wg_device *wg, const u8 pubkey[NOISE_PUBLIC_KEY_LEN],
-	                           struct endpoint *endpoint, bool advanced_security)
+	                           struct endpoint *endpoint, bool advanced_security,
+	                           bool ranged_headers)
 {
 	struct sk_buff *skb;
 	struct nlattr *peer_nest;
@@ -1061,6 +1078,11 @@ int wg_genl_mcast_peer_unknown(struct wg_device *wg, const u8 pubkey[NOISE_PUBLI
 		ret = nla_put_flag(skb, WGPEER_A_ADVANCED_SECURITY);
 		if (ret)
 			goto err;
+		if (ranged_headers) {
+			ret = nla_put_flag(skb, WGPEER_A_RANGED_HEADERS);
+			if (ret)
+				goto err;
+		}
 	}
 
 	nla_nest_end(skb, peer_nest);

--- a/src/netlink.h
+++ b/src/netlink.h
@@ -14,7 +14,8 @@ extern char *bogus_endpoints_prefix;
 extern char *bogus_endpoints_prefix6;
 
 int wg_genl_mcast_peer_unknown(struct wg_device *wg, const u8 pubkey[NOISE_PUBLIC_KEY_LEN],
-	                           struct endpoint *endpoint, bool advanced_security);
+	                           struct endpoint *endpoint, bool advanced_security,
+	                           bool ranged_headers);
 int wg_genetlink_init(void);
 void wg_genetlink_uninit(void);
 

--- a/src/noise.c
+++ b/src/noise.c
@@ -600,6 +600,9 @@ wg_noise_handshake_consume_initiation(struct message_handshake_initiation *src,
 	u64 initiation_consumption;
 	bool advanced_security = wg->advanced_security &&
 	                         mh_validate(SKB_TYPE_LE32(skb), &wg->headers[MSGIDX_HANDSHAKE_INIT]);
+	bool ranged_headers = advanced_security &&
+	                      (le32_to_cpu(SKB_TYPE_LE32(skb)) !=
+	                       wg->headers[MSGIDX_HANDSHAKE_INIT].start);
 
 	down_read(&wg->static_identity.lock);
 	if (unlikely(!wg->static_identity.has_identity))
@@ -626,11 +629,13 @@ wg_noise_handshake_consume_initiation(struct message_handshake_initiation *src,
 			goto out;
 
 		net_dbg_skb_ratelimited("%s: unknown peer from %pISpfsc\n", wg->dev->name, skb);
-		wg_genl_mcast_peer_unknown(wg, s, endpoint, advanced_security);
+		wg_genl_mcast_peer_unknown(wg, s, endpoint,
+					   advanced_security, ranged_headers);
 		goto out;
 	}
 	handshake = &peer->handshake;
 	peer->advanced_security = advanced_security;
+	peer->ranged_headers = ranged_headers;
 
 	/* ss */
 	if (!mix_precomputed_dh(chaining_key, key,

--- a/src/peer.c
+++ b/src/peer.c
@@ -37,6 +37,10 @@ struct wg_peer *wg_peer_create(struct wg_device *wg,
 		goto err;
 
 	peer->device = wg;
+	peer->advanced_security = wg->advanced_security;
+	peer->ranged_headers = wg->advanced_security &&
+			       (wg->headers[MSGIDX_HANDSHAKE_INIT].start !=
+				wg->headers[MSGIDX_HANDSHAKE_INIT].end);
 	wg_noise_handshake_init(&peer->handshake, &wg->static_identity,
 				public_key, preshared_key, peer);
 	peer->internal_id = atomic64_inc_return(&peer_counter);

--- a/src/peer.h
+++ b/src/peer.h
@@ -66,6 +66,7 @@ struct wg_peer {
 	u64 internal_id;
 	atomic_t jp_packet_counter;
 	bool advanced_security;
+	bool ranged_headers;
 };
 
 struct wg_peer *wg_peer_create(struct wg_device *wg,

--- a/src/receive.c
+++ b/src/receive.c
@@ -67,6 +67,20 @@ static size_t prepare_awg_message(struct sk_buff *skb, struct wg_device *wg)
 			skb_push(skb, wg->junk_size[MSGIDX_TRANSPORT]);
 	}
 
+	/* Legacy WireGuard client support: accept standard packets */
+	if (skb->len == MESSAGE_INITIATION_SIZE &&
+	    SKB_TYPE_LE32(skb) == cpu_to_le32(MESSAGE_HANDSHAKE_INITIATION))
+		return MESSAGE_INITIATION_SIZE;
+	if (skb->len == MESSAGE_RESPONSE_SIZE &&
+	    SKB_TYPE_LE32(skb) == cpu_to_le32(MESSAGE_HANDSHAKE_RESPONSE))
+		return MESSAGE_RESPONSE_SIZE;
+	if (skb->len == MESSAGE_COOKIE_REPLY_SIZE &&
+	    SKB_TYPE_LE32(skb) == cpu_to_le32(MESSAGE_HANDSHAKE_COOKIE))
+		return MESSAGE_COOKIE_REPLY_SIZE;
+	if (skb->len >= MESSAGE_MINIMUM_LENGTH &&
+	    SKB_TYPE_LE32(skb) == cpu_to_le32(MESSAGE_DATA))
+		return MESSAGE_TRANSPORT_SIZE;
+
 	net_dbg_skb_ratelimited("%s: Unknown message from %pISpfsc encountered, packet dropped\n",
 								wg->dev->name, skb);
 
@@ -130,7 +144,8 @@ static void wg_receive_handshake_packet(struct wg_device *wg,
 	bool packet_needs_cookie;
 	bool under_load;
 
-	if (mh_validate(SKB_TYPE_LE32(skb), &wg->headers[MSGIDX_HANDSHAKE_COOKIE])) {
+	if (mh_validate(SKB_TYPE_LE32(skb), &wg->headers[MSGIDX_HANDSHAKE_COOKIE]) ||
+	    SKB_TYPE_LE32(skb) == cpu_to_le32(MESSAGE_HANDSHAKE_COOKIE)) {
 		net_dbg_skb_ratelimited("%s: Receiving cookie response from %pISpfsc\n",
 					wg->dev->name, skb);
 		wg_cookie_message_consume(
@@ -160,7 +175,8 @@ static void wg_receive_handshake_packet(struct wg_device *wg,
 		return;
 	}
 
-	if (mh_validate(SKB_TYPE_LE32(skb), &wg->headers[MSGIDX_HANDSHAKE_INIT])) {
+	if (mh_validate(SKB_TYPE_LE32(skb), &wg->headers[MSGIDX_HANDSHAKE_INIT]) ||
+	    SKB_TYPE_LE32(skb) == cpu_to_le32(MESSAGE_HANDSHAKE_INITIATION)) {
 		struct message_handshake_initiation *message =
 			(struct message_handshake_initiation *)skb->data;
 
@@ -181,7 +197,8 @@ static void wg_receive_handshake_packet(struct wg_device *wg,
 				    &peer->endpoint.addr);
 		wg_packet_send_handshake_response(peer);
 	}
-	if (mh_validate(SKB_TYPE_LE32(skb), &wg->headers[MSGIDX_HANDSHAKE_RESPONSE])) {
+	if (mh_validate(SKB_TYPE_LE32(skb), &wg->headers[MSGIDX_HANDSHAKE_RESPONSE]) ||
+	    SKB_TYPE_LE32(skb) == cpu_to_le32(MESSAGE_HANDSHAKE_RESPONSE)) {
 		struct message_handshake_response *message =
 			(struct message_handshake_response *)skb->data;
 
@@ -585,8 +602,11 @@ void wg_packet_receive(struct wg_device *wg, struct sk_buff *skb)
 		goto err;
 
 	if (mh_validate(SKB_TYPE_LE32(skb), &wg->headers[MSGIDX_HANDSHAKE_INIT]) ||
-		mh_validate(SKB_TYPE_LE32(skb), &wg->headers[MSGIDX_HANDSHAKE_RESPONSE]) ||
-		mh_validate(SKB_TYPE_LE32(skb), &wg->headers[MSGIDX_HANDSHAKE_COOKIE])) {
+	    mh_validate(SKB_TYPE_LE32(skb), &wg->headers[MSGIDX_HANDSHAKE_RESPONSE]) ||
+	    mh_validate(SKB_TYPE_LE32(skb), &wg->headers[MSGIDX_HANDSHAKE_COOKIE]) ||
+	    SKB_TYPE_LE32(skb) == cpu_to_le32(MESSAGE_HANDSHAKE_INITIATION) ||
+	    SKB_TYPE_LE32(skb) == cpu_to_le32(MESSAGE_HANDSHAKE_RESPONSE) ||
+	    SKB_TYPE_LE32(skb) == cpu_to_le32(MESSAGE_HANDSHAKE_COOKIE)) {
 		int cpu, ret = -EBUSY;
 
 		if (unlikely(!rng_is_initialized()))
@@ -609,7 +629,8 @@ void wg_packet_receive(struct wg_device *wg, struct sk_buff *skb)
 		/* Queues up a call to packet_process_queued_handshake_packets(skb): */
 		queue_work_on(cpu, wg->handshake_receive_wq,
 			      &per_cpu_ptr(wg->handshake_queue.worker, cpu)->work);
-	} else if (mh_validate(SKB_TYPE_LE32(skb), &wg->headers[MSGIDX_TRANSPORT])) {
+	} else if (mh_validate(SKB_TYPE_LE32(skb), &wg->headers[MSGIDX_TRANSPORT]) ||
+		   SKB_TYPE_LE32(skb) == cpu_to_le32(MESSAGE_DATA)) {
 		PACKET_CB(skb)->ds = ip_tunnel_get_dsfield(ip_hdr(skb), skb);
 		wg_packet_consume_data(wg, skb);
 	} else {

--- a/src/send.c
+++ b/src/send.c
@@ -43,46 +43,52 @@ static void wg_packet_send_handshake_initiation(struct wg_peer *peer)
 			    peer->device->dev->name, peer->internal_id,
 			    &peer->endpoint.addr);
 
-	atomic_set(&peer->jp_packet_counter, get_random_u32());
-	for (i = 0; i < ARRAY_SIZE(wg->ispecs); ++i)
-	{
-		spec = &wg->ispecs[i];
-		if (spec->pkt_size > 0) {
-			mutex_lock(&spec->lock);
-			jp_spec_applymods(spec, peer);
-			wg_socket_send_buffer_to_peer(peer, spec->pkt, spec->pkt_size, 0, 0);
-			atomic_inc(&peer->jp_packet_counter);
-			mutex_unlock(&spec->lock);
-		}
-	}
-	
-	if (wg->jc && wg->jmax) {
-		net_dbg_ratelimited("%s: Sending dummy junk packets to %llu (%pISpfsc)\n",
-			    peer->device->dev->name, peer->internal_id,
-			    &peer->endpoint.addr);
-
-		junk_packet_count = wg->jc;
-		buffer = kzalloc(wg->jmax, GFP_KERNEL);
-
-		while (junk_packet_count-- > 0) {
-			junk_packet_size = (u16) get_random_u32_inclusive(wg->jmin, wg->jmax);
-
-			get_random_bytes(buffer, junk_packet_size);
-			get_random_bytes(&ds, 1);
-			wg_socket_send_buffer_to_peer(peer, buffer, junk_packet_size, ds, 0);
+	if (peer->advanced_security) {
+		atomic_set(&peer->jp_packet_counter, get_random_u32());
+		for (i = 0; i < ARRAY_SIZE(wg->ispecs); ++i) {
+			spec = &wg->ispecs[i];
+			if (spec->pkt_size > 0) {
+				mutex_lock(&spec->lock);
+				jp_spec_applymods(spec, peer);
+				wg_socket_send_buffer_to_peer(peer, spec->pkt, spec->pkt_size, 0, 0);
+				atomic_inc(&peer->jp_packet_counter);
+				mutex_unlock(&spec->lock);
+			}
 		}
 
-		kfree(buffer);
+		if (wg->jc && wg->jmax) {
+			net_dbg_ratelimited("%s: Sending dummy junk packets to %llu (%pISpfsc)\n",
+					    peer->device->dev->name, peer->internal_id,
+					    &peer->endpoint.addr);
+
+			junk_packet_count = wg->jc;
+			buffer = kzalloc(wg->jmax, GFP_KERNEL);
+
+			while (junk_packet_count-- > 0) {
+				junk_packet_size = (u16) get_random_u32_inclusive(wg->jmin, wg->jmax);
+
+				get_random_bytes(buffer, junk_packet_size);
+				get_random_bytes(&ds, 1);
+				wg_socket_send_buffer_to_peer(peer, buffer, junk_packet_size, ds, 0);
+			}
+
+			kfree(buffer);
+		}
 	}
 
-	if (wg_noise_handshake_create_initiation(&packet, &peer->handshake, mh_genheader(&wg->headers[MSGIDX_HANDSHAKE_INIT]))) {
+	if (wg_noise_handshake_create_initiation(&packet, &peer->handshake,
+			peer->advanced_security ?
+			mh_genheader(&wg->headers[MSGIDX_HANDSHAKE_INIT]) :
+			MESSAGE_HANDSHAKE_INITIATION)) {
 		wg_cookie_add_mac_to_packet(&packet, sizeof(packet), peer);
 		wg_timers_any_authenticated_packet_traversal(peer);
 		wg_timers_any_authenticated_packet_sent(peer);
 		atomic64_set(&peer->last_sent_handshake,
 			     ktime_get_coarse_boottime_ns());
 		wg_socket_send_buffer_to_peer(peer, &packet, sizeof(packet),
-					      HANDSHAKE_DSCP, wg->junk_size[MSGIDX_HANDSHAKE_INIT]);
+					      HANDSHAKE_DSCP,
+					      peer->advanced_security ?
+					      wg->junk_size[MSGIDX_HANDSHAKE_INIT] : 0);
 		wg_timers_handshake_initiated(peer);
 	}
 }
@@ -136,7 +142,10 @@ void wg_packet_send_handshake_response(struct wg_peer *peer)
 			    peer->device->dev->name, peer->internal_id,
 			    &peer->endpoint.addr);
 
-	if (wg_noise_handshake_create_response(&packet, &peer->handshake, mh_genheader(&wg->headers[MSGIDX_HANDSHAKE_RESPONSE]))) {
+	if (wg_noise_handshake_create_response(&packet, &peer->handshake,
+			peer->advanced_security ?
+			mh_genheader(&wg->headers[MSGIDX_HANDSHAKE_RESPONSE]) :
+			MESSAGE_HANDSHAKE_RESPONSE)) {
 		wg_cookie_add_mac_to_packet(&packet, sizeof(packet), peer);
 		if (wg_noise_handshake_begin_session(&peer->handshake,
 						     &peer->keypairs)) {
@@ -148,7 +157,8 @@ void wg_packet_send_handshake_response(struct wg_peer *peer)
 			wg_socket_send_buffer_to_peer(peer, &packet,
 						      sizeof(packet),
 						      HANDSHAKE_DSCP,
-							  wg->junk_size[MSGIDX_HANDSHAKE_RESPONSE]);
+						      peer->advanced_security ?
+						      wg->junk_size[MSGIDX_HANDSHAKE_RESPONSE] : 0);
 		}
 	}
 }
@@ -161,12 +171,21 @@ void wg_packet_send_handshake_cookie(struct wg_device *wg,
 
 	net_dbg_skb_ratelimited("%s: Sending cookie response for denied handshake message for %pISpfsc\n",
 				wg->dev->name, initiating_skb);
-	wg_cookie_message_create(&packet, initiating_skb, sender_index,
-				 &wg->cookie_checker,
-				 mh_genheader(&wg->headers[MSGIDX_HANDSHAKE_COOKIE]));
-	wg_socket_send_buffer_as_reply_to_skb(wg, initiating_skb, &packet,
-					      sizeof(packet),
-						  wg->junk_size[MSGIDX_HANDSHAKE_COOKIE]);
+	if (SKB_TYPE_LE32(initiating_skb) == cpu_to_le32(MESSAGE_HANDSHAKE_INITIATION) ||
+	    SKB_TYPE_LE32(initiating_skb) == cpu_to_le32(MESSAGE_HANDSHAKE_RESPONSE)) {
+		wg_cookie_message_create(&packet, initiating_skb, sender_index,
+					 &wg->cookie_checker,
+					 MESSAGE_HANDSHAKE_COOKIE);
+		wg_socket_send_buffer_as_reply_to_skb(wg, initiating_skb,
+						      &packet, sizeof(packet), 0);
+	} else {
+		wg_cookie_message_create(&packet, initiating_skb, sender_index,
+					 &wg->cookie_checker,
+					 mh_genheader(&wg->headers[MSGIDX_HANDSHAKE_COOKIE]));
+		wg_socket_send_buffer_as_reply_to_skb(wg, initiating_skb,
+						      &packet, sizeof(packet),
+						      wg->junk_size[MSGIDX_HANDSHAKE_COOKIE]);
+	}
 }
 
 static void keep_key_fresh(struct wg_peer *peer)
@@ -354,8 +373,11 @@ void wg_packet_encrypt_worker(struct work_struct *work)
 			wg = PACKET_PEER(first)->device;
 
 			if (likely(encrypt_packet(
-						  mh_genheader(&wg->headers[MSGIDX_TRANSPORT]),
-						  wg->junk_size[MSGIDX_TRANSPORT],
+						  PACKET_PEER(first)->advanced_security ?
+						  mh_genheader(&wg->headers[MSGIDX_TRANSPORT]) :
+						  MESSAGE_DATA,
+						  PACKET_PEER(first)->advanced_security ?
+						  wg->junk_size[MSGIDX_TRANSPORT] : 0,
 						  skb,
 						  PACKET_CB(first)->keypair
 						  COMPAT_MAYBE_SIMD_CONTEXT(&simd_context)))) {

--- a/src/send.c
+++ b/src/send.c
@@ -78,7 +78,8 @@ static void wg_packet_send_handshake_initiation(struct wg_peer *peer)
 
 	if (wg_noise_handshake_create_initiation(&packet, &peer->handshake,
 			peer->advanced_security ?
-			mh_genheader(&wg->headers[MSGIDX_HANDSHAKE_INIT]) :
+			mh_peerheader(&wg->headers[MSGIDX_HANDSHAKE_INIT],
+				      peer->ranged_headers) :
 			MESSAGE_HANDSHAKE_INITIATION)) {
 		wg_cookie_add_mac_to_packet(&packet, sizeof(packet), peer);
 		wg_timers_any_authenticated_packet_traversal(peer);
@@ -144,7 +145,8 @@ void wg_packet_send_handshake_response(struct wg_peer *peer)
 
 	if (wg_noise_handshake_create_response(&packet, &peer->handshake,
 			peer->advanced_security ?
-			mh_genheader(&wg->headers[MSGIDX_HANDSHAKE_RESPONSE]) :
+			mh_peerheader(&wg->headers[MSGIDX_HANDSHAKE_RESPONSE],
+				      peer->ranged_headers) :
 			MESSAGE_HANDSHAKE_RESPONSE)) {
 		wg_cookie_add_mac_to_packet(&packet, sizeof(packet), peer);
 		if (wg_noise_handshake_begin_session(&peer->handshake,
@@ -168,24 +170,41 @@ void wg_packet_send_handshake_cookie(struct wg_device *wg,
 				     __le32 sender_index)
 {
 	struct message_handshake_cookie packet;
+	__le32 type = SKB_TYPE_LE32(initiating_skb);
+	u32 host_type = le32_to_cpu(type);
+	bool is_legacy, is_ranged;
+	u32 cookie_header;
+	size_t cookie_junk;
+
+	is_legacy = (type == cpu_to_le32(MESSAGE_HANDSHAKE_INITIATION) ||
+		     type == cpu_to_le32(MESSAGE_HANDSHAKE_RESPONSE));
+
+	/* Detect AWG 2.0 vs 1.0: if the incoming header is not at the
+	 * start of its range, the peer must support ranged headers.
+	 */
+	is_ranged = false;
+	if (!is_legacy) {
+		if (mh_validate(type, &wg->headers[MSGIDX_HANDSHAKE_INIT]))
+			is_ranged = (host_type != wg->headers[MSGIDX_HANDSHAKE_INIT].start);
+		else if (mh_validate(type, &wg->headers[MSGIDX_HANDSHAKE_RESPONSE]))
+			is_ranged = (host_type != wg->headers[MSGIDX_HANDSHAKE_RESPONSE].start);
+	}
+
+	if (is_legacy) {
+		cookie_header = MESSAGE_HANDSHAKE_COOKIE;
+		cookie_junk = 0;
+	} else {
+		cookie_header = mh_peerheader(&wg->headers[MSGIDX_HANDSHAKE_COOKIE],
+					      is_ranged);
+		cookie_junk = wg->junk_size[MSGIDX_HANDSHAKE_COOKIE];
+	}
 
 	net_dbg_skb_ratelimited("%s: Sending cookie response for denied handshake message for %pISpfsc\n",
 				wg->dev->name, initiating_skb);
-	if (SKB_TYPE_LE32(initiating_skb) == cpu_to_le32(MESSAGE_HANDSHAKE_INITIATION) ||
-	    SKB_TYPE_LE32(initiating_skb) == cpu_to_le32(MESSAGE_HANDSHAKE_RESPONSE)) {
-		wg_cookie_message_create(&packet, initiating_skb, sender_index,
-					 &wg->cookie_checker,
-					 MESSAGE_HANDSHAKE_COOKIE);
-		wg_socket_send_buffer_as_reply_to_skb(wg, initiating_skb,
-						      &packet, sizeof(packet), 0);
-	} else {
-		wg_cookie_message_create(&packet, initiating_skb, sender_index,
-					 &wg->cookie_checker,
-					 mh_genheader(&wg->headers[MSGIDX_HANDSHAKE_COOKIE]));
-		wg_socket_send_buffer_as_reply_to_skb(wg, initiating_skb,
-						      &packet, sizeof(packet),
-						      wg->junk_size[MSGIDX_HANDSHAKE_COOKIE]);
-	}
+	wg_cookie_message_create(&packet, initiating_skb, sender_index,
+				 &wg->cookie_checker, cookie_header);
+	wg_socket_send_buffer_as_reply_to_skb(wg, initiating_skb,
+					      &packet, sizeof(packet), cookie_junk);
 }
 
 static void keep_key_fresh(struct wg_peer *peer)
@@ -374,7 +393,8 @@ void wg_packet_encrypt_worker(struct work_struct *work)
 
 			if (likely(encrypt_packet(
 						  PACKET_PEER(first)->advanced_security ?
-						  mh_genheader(&wg->headers[MSGIDX_TRANSPORT]) :
+						  mh_peerheader(&wg->headers[MSGIDX_TRANSPORT],
+								PACKET_PEER(first)->ranged_headers) :
 						  MESSAGE_DATA,
 						  PACKET_PEER(first)->advanced_security ?
 						  wg->junk_size[MSGIDX_TRANSPORT] : 0,

--- a/src/uapi/wireguard.h
+++ b/src/uapi/wireguard.h
@@ -118,6 +118,9 @@
  *            WGPEER_A_ADVANCED_SECURITY: flag indicating that advanced security
  *                                       techniques provided by AmneziaWG should
  *                                       be used.
+ *            WGPEER_A_RANGED_HEADERS: flag indicating that the peer supports
+ *                                     ranged (AWG 2.0) magic headers rather
+ *                                     than fixed (AWG 1.0) values.
  *        0: NLA_NESTED
  *            ...
  *        ...
@@ -228,6 +231,7 @@ enum wgpeer_attribute {
 	WGPEER_A_ALLOWEDIPS,
 	WGPEER_A_PROTOCOL_VERSION,
 	WGPEER_A_ADVANCED_SECURITY,
+	WGPEER_A_RANGED_HEADERS,
 	__WGPEER_A_LAST
 };
 #define WGPEER_A_MAX (__WGPEER_A_LAST - 1)


### PR DESCRIPTION
## Summary

When an AWG 2.0 server has ranged H1-H4 values, it generates random headers from those ranges for all AWG peers via `mh_genheader()`. This breaks AWG 1.0 clients that expect exact fixed values (the range starts).

This PR adds per-peer detection of fixed vs ranged header support:

- Add `ranged_headers` field to `struct wg_peer`
- Add `mh_peerheader()` helper: returns range start for fixed (AWG 1.0) peers, random value for ranged (AWG 2.0) peers
- Auto-detect in `noise.c` during handshake consumption: if the peer's init header differs from the range start, it must support ranged headers
- Apply same detection logic in cookie responses
- Default `ranged_headers` for netlink-configured peers based on whether the device's header ranges are actual ranges

### Detection heuristic and its limitations

The detection works by comparing the incoming H1 value against the configured range start:

- Value != range start → peer supports ranged headers (AWG 2.0)
- Value == range start → peer uses fixed headers (AWG 1.0)

This heuristic is conservative and safe in the "wrong" direction:

- If an AWG 2.0 peer's random H1 happens to land on the range start, it is classified as AWG 1.0. The server responds with range start values, which are valid within the range — the 2.0 peer accepts them. No breakage.
- Important: AWG 1.0 clients MUST be configured with H1-H4 values equal to the range start values of the AWG 2.0 server. If a 1.0 client uses a fixed value that falls within the range but is not the range start (e.g., client has H1=150 while server has H1=100-200), the server will misclassify it as AWG 2.0 and respond with random values from the range, which the 1.0 client will reject. This is an inherent limitation of heuristic detection without explicit version negotiation in the handshake.

### UAPI extension

Expose the new flag to userspace via `WGPEER_A_RANGED_HEADERS` netlink attribute (backward compatible — old userspace ignores unknown attributes). This allows userspace apps to distinguish three peer states:

| `advanced_security` | `ranged_headers` | Peer type |
|---|---|---|
| false | - | Legacy WireGuard |
| true | false | AWG 1.0 (fixed headers) |
| true | true | AWG 2.0 (ranged headers) |

**Depends on #164** — must be merged first.

## Test plan

- [x] AWG 1.0 client (fixed H1-H4 at range starts) connects to AWG 2.0 server (ranged H1-H4)
- [x] AWG 2.0 client (ranged H1-H4) connects to AWG 2.0 server
- [x] Legacy WireGuard client still connects (unchanged from #164)
- [x] Userspace can read `WGPEER_A_RANGED_HEADERS` attribute for connected peers
- [x] Make sure it doesn't break the client mode

Closes #163