### PR TITLE
fix: per-peer S3-S4 junk offset detection for backward compatibility

### DIFF
--- a/src/magic_header.h
+++ b/src/magic_header.h
@@ -14,4 +14,13 @@ int mh_genspec(struct magic_header *mh, char *desc, size_t buflen);
 bool mh_validate(__le32 received, struct magic_header* mh);
 u32 mh_genheader(struct magic_header* mh);
 
+/* Generate a header appropriate for the peer's capability level.
+ * Ranged peers get a random value from the range (AWG 2.0).
+ * Fixed peers get the range start value (AWG 1.0 compatibility).
+ */
+static inline u32 mh_peerheader(struct magic_header *mh, bool ranged)
+{
+	return ranged ? mh_genheader(mh) : mh->start;
+}
+
 #endif

--- a/src/netlink.c
+++ b/src/netlink.c
@@ -72,7 +72,8 @@ static const struct nla_policy peer_policy[WGPEER_A_MAX + 1] = {
 	[WGPEER_A_TX_BYTES]				= { .type = NLA_U64 },
 	[WGPEER_A_ALLOWEDIPS]				= { .type = NLA_NESTED },
 	[WGPEER_A_PROTOCOL_VERSION]			= { .type = NLA_U32 },
-	[WGPEER_A_ADVANCED_SECURITY]    		= { .type = NLA_FLAG }
+	[WGPEER_A_ADVANCED_SECURITY]    		= { .type = NLA_FLAG },
+	[WGPEER_A_RANGED_HEADERS]			= { .type = NLA_FLAG }
 };
 
 static const struct nla_policy allowedip_policy[WGALLOWEDIP_A_MAX + 1] = {
@@ -297,6 +298,11 @@ get_peer(struct wg_peer *peer, struct sk_buff *skb, struct dump_ctx *ctx)
 		fail = nla_put_flag(skb, WGPEER_A_ADVANCED_SECURITY);
 		if (fail)
 			goto err;
+		if (peer->ranged_headers) {
+			fail = nla_put_flag(skb, WGPEER_A_RANGED_HEADERS);
+			if (fail)
+				goto err;
+		}
 	}
 
 	down_read(&peer->handshake.lock);
@@ -718,6 +724,16 @@ static int set_peer(struct wg_device *wg, struct nlattr **attrs)
 	if (flags & WGPEER_F_HAS_ADVANCED_SECURITY) {
 		peer->advanced_security = wg->advanced_security &&
 				nla_get_flag(attrs[WGPEER_A_ADVANCED_SECURITY]);
+		if (attrs[WGPEER_A_RANGED_HEADERS])
+			peer->ranged_headers = peer->advanced_security &&
+				nla_get_flag(attrs[WGPEER_A_RANGED_HEADERS]);
+		else
+			/* Default based on whether device uses ranges.
+			 * Will be auto-corrected on first incoming handshake.
+			 */
+			peer->ranged_headers = peer->advanced_security &&
+				(wg->headers[MSGIDX_HANDSHAKE_INIT].start !=
+				 wg->headers[MSGIDX_HANDSHAKE_INIT].end);
 	}
 
 	if (netif_running(wg->dev))
@@ -1016,7 +1032,8 @@ void __exit wg_genetlink_uninit(void)
 }
 
 int wg_genl_mcast_peer_unknown(struct wg_device *wg, const u8 pubkey[NOISE_PUBLIC_KEY_LEN],
-	                           struct endpoint *endpoint, bool advanced_security)
+	                           struct endpoint *endpoint, bool advanced_security,
+	                           bool ranged_headers)
 {
 	struct sk_buff *skb;
 	struct nlattr *peer_nest;
@@ -1061,6 +1078,11 @@ int wg_genl_mcast_peer_unknown(struct wg_device *wg, const u8 pubkey[NOISE_PUBLI
 		ret = nla_put_flag(skb, WGPEER_A_ADVANCED_SECURITY);
 		if (ret)
 			goto err;
+		if (ranged_headers) {
+			ret = nla_put_flag(skb, WGPEER_A_RANGED_HEADERS);
+			if (ret)
+				goto err;
+		}
 	}
 
 	nla_nest_end(skb, peer_nest);

--- a/src/netlink.c
+++ b/src/netlink.c
@@ -323,6 +323,10 @@ get_peer(struct wg_peer *peer, struct sk_buff *skb, struct dump_ctx *ctx)
 			.tv_sec = peer->walltime_last_handshake.tv_sec,
 			.tv_nsec = peer->walltime_last_handshake.tv_nsec
 		};
+		const struct __kernel_timespec last_data = {
+			.tv_sec = peer->walltime_last_data.tv_sec,
+			.tv_nsec = peer->walltime_last_data.tv_nsec
+		};
 
 		down_read(&peer->handshake.lock);
 		fail = nla_put(skb, WGPEER_A_PRESHARED_KEY,
@@ -334,6 +338,8 @@ get_peer(struct wg_peer *peer, struct sk_buff *skb, struct dump_ctx *ctx)
 
 		if (nla_put(skb, WGPEER_A_LAST_HANDSHAKE_TIME,
 			    sizeof(last_handshake), &last_handshake) ||
+		    nla_put(skb, WGPEER_A_LAST_DATA_TIME,
+			    sizeof(last_data), &last_data) ||
 		    nla_put_u16(skb, WGPEER_A_PERSISTENT_KEEPALIVE_INTERVAL,
 				peer->persistent_keepalive_interval) ||
 		    nla_put_u64_64bit(skb, WGPEER_A_TX_BYTES, peer->tx_bytes,

--- a/src/netlink.c
+++ b/src/netlink.c
@@ -73,7 +73,8 @@ static const struct nla_policy peer_policy[WGPEER_A_MAX + 1] = {
 	[WGPEER_A_ALLOWEDIPS]				= { .type = NLA_NESTED },
 	[WGPEER_A_PROTOCOL_VERSION]			= { .type = NLA_U32 },
 	[WGPEER_A_ADVANCED_SECURITY]    		= { .type = NLA_FLAG },
-	[WGPEER_A_RANGED_HEADERS]			= { .type = NLA_FLAG }
+	[WGPEER_A_RANGED_HEADERS]			= { .type = NLA_FLAG },
+	[WGPEER_A_JUNK_OFFSETS]				= { .type = NLA_FLAG }
 };
 
 static const struct nla_policy allowedip_policy[WGALLOWEDIP_A_MAX + 1] = {
@@ -300,6 +301,11 @@ get_peer(struct wg_peer *peer, struct sk_buff *skb, struct dump_ctx *ctx)
 			goto err;
 		if (peer->ranged_headers) {
 			fail = nla_put_flag(skb, WGPEER_A_RANGED_HEADERS);
+			if (fail)
+				goto err;
+		}
+		if (peer->junk_offsets) {
+			fail = nla_put_flag(skb, WGPEER_A_JUNK_OFFSETS);
 			if (fail)
 				goto err;
 		}
@@ -734,6 +740,13 @@ static int set_peer(struct wg_device *wg, struct nlattr **attrs)
 			peer->ranged_headers = peer->advanced_security &&
 				(wg->headers[MSGIDX_HANDSHAKE_INIT].start !=
 				 wg->headers[MSGIDX_HANDSHAKE_INIT].end);
+		if (attrs[WGPEER_A_JUNK_OFFSETS])
+			peer->junk_offsets = peer->advanced_security &&
+				nla_get_flag(attrs[WGPEER_A_JUNK_OFFSETS]);
+		/* else: leave junk_offsets unchanged — it is auto-detected
+		 * from transport packets and must not be reset when the
+		 * userspace tool doesn't explicitly provide it.
+		 */
 	}
 
 	if (netif_running(wg->dev))
@@ -1033,7 +1046,7 @@ void __exit wg_genetlink_uninit(void)
 
 int wg_genl_mcast_peer_unknown(struct wg_device *wg, const u8 pubkey[NOISE_PUBLIC_KEY_LEN],
 	                           struct endpoint *endpoint, bool advanced_security,
-	                           bool ranged_headers)
+	                           bool ranged_headers, bool junk_offsets)
 {
 	struct sk_buff *skb;
 	struct nlattr *peer_nest;
@@ -1080,6 +1093,11 @@ int wg_genl_mcast_peer_unknown(struct wg_device *wg, const u8 pubkey[NOISE_PUBLI
 			goto err;
 		if (ranged_headers) {
 			ret = nla_put_flag(skb, WGPEER_A_RANGED_HEADERS);
+			if (ret)
+				goto err;
+		}
+		if (junk_offsets) {
+			ret = nla_put_flag(skb, WGPEER_A_JUNK_OFFSETS);
 			if (ret)
 				goto err;
 		}

--- a/src/netlink.h
+++ b/src/netlink.h
@@ -14,7 +14,8 @@ extern char *bogus_endpoints_prefix;
 extern char *bogus_endpoints_prefix6;
 
 int wg_genl_mcast_peer_unknown(struct wg_device *wg, const u8 pubkey[NOISE_PUBLIC_KEY_LEN],
-	                           struct endpoint *endpoint, bool advanced_security);
+	                           struct endpoint *endpoint, bool advanced_security,
+	                           bool ranged_headers);
 int wg_genetlink_init(void);
 void wg_genetlink_uninit(void);
 

--- a/src/netlink.h
+++ b/src/netlink.h
@@ -15,7 +15,7 @@ extern char *bogus_endpoints_prefix6;
 
 int wg_genl_mcast_peer_unknown(struct wg_device *wg, const u8 pubkey[NOISE_PUBLIC_KEY_LEN],
 	                           struct endpoint *endpoint, bool advanced_security,
-	                           bool ranged_headers);
+	                           bool ranged_headers, bool junk_offsets);
 int wg_genetlink_init(void);
 void wg_genetlink_uninit(void);
 

--- a/src/noise.c
+++ b/src/noise.c
@@ -600,6 +600,9 @@ wg_noise_handshake_consume_initiation(struct message_handshake_initiation *src,
 	u64 initiation_consumption;
 	bool advanced_security = wg->advanced_security &&
 	                         mh_validate(SKB_TYPE_LE32(skb), &wg->headers[MSGIDX_HANDSHAKE_INIT]);
+	bool ranged_headers = advanced_security &&
+	                      (le32_to_cpu(SKB_TYPE_LE32(skb)) !=
+	                       wg->headers[MSGIDX_HANDSHAKE_INIT].start);
 
 	down_read(&wg->static_identity.lock);
 	if (unlikely(!wg->static_identity.has_identity))
@@ -626,11 +629,13 @@ wg_noise_handshake_consume_initiation(struct message_handshake_initiation *src,
 			goto out;
 
 		net_dbg_skb_ratelimited("%s: unknown peer from %pISpfsc\n", wg->dev->name, skb);
-		wg_genl_mcast_peer_unknown(wg, s, endpoint, advanced_security);
+		wg_genl_mcast_peer_unknown(wg, s, endpoint,
+					   advanced_security, ranged_headers);
 		goto out;
 	}
 	handshake = &peer->handshake;
 	peer->advanced_security = advanced_security;
+	peer->ranged_headers = ranged_headers;
 
 	/* ss */
 	if (!mix_precomputed_dh(chaining_key, key,

--- a/src/noise.c
+++ b/src/noise.c
@@ -603,6 +603,9 @@ wg_noise_handshake_consume_initiation(struct message_handshake_initiation *src,
 	bool ranged_headers = advanced_security &&
 	                      (le32_to_cpu(SKB_TYPE_LE32(skb)) !=
 	                       wg->headers[MSGIDX_HANDSHAKE_INIT].start);
+	bool junk_offsets = advanced_security &&
+	                    (wg->junk_size[MSGIDX_HANDSHAKE_COOKIE] > 0 ||
+	                     wg->junk_size[MSGIDX_TRANSPORT] > 0);
 
 	down_read(&wg->static_identity.lock);
 	if (unlikely(!wg->static_identity.has_identity))
@@ -630,12 +633,19 @@ wg_noise_handshake_consume_initiation(struct message_handshake_initiation *src,
 
 		net_dbg_skb_ratelimited("%s: unknown peer from %pISpfsc\n", wg->dev->name, skb);
 		wg_genl_mcast_peer_unknown(wg, s, endpoint,
-					   advanced_security, ranged_headers);
+					   advanced_security, ranged_headers,
+					   junk_offsets);
 		goto out;
 	}
 	handshake = &peer->handshake;
 	peer->advanced_security = advanced_security;
 	peer->ranged_headers = ranged_headers;
+	/* Don't reset junk_offsets here — the handshake carries no
+	 * information about whether the client uses S3/S4.  The initial
+	 * value from wg_peer_create (server default) is refined by the
+	 * transport data path in wg_packet_consume_data, and must survive
+	 * across re-handshakes.
+	 */
 
 	/* ss */
 	if (!mix_precomputed_dh(chaining_key, key,

--- a/src/peer.c
+++ b/src/peer.c
@@ -37,6 +37,10 @@ struct wg_peer *wg_peer_create(struct wg_device *wg,
 		goto err;
 
 	peer->device = wg;
+	peer->advanced_security = wg->advanced_security;
+	peer->ranged_headers = wg->advanced_security &&
+			       (wg->headers[MSGIDX_HANDSHAKE_INIT].start !=
+				wg->headers[MSGIDX_HANDSHAKE_INIT].end);
 	wg_noise_handshake_init(&peer->handshake, &wg->static_identity,
 				public_key, preshared_key, peer);
 	peer->internal_id = atomic64_inc_return(&peer_counter);

--- a/src/peer.c
+++ b/src/peer.c
@@ -41,6 +41,9 @@ struct wg_peer *wg_peer_create(struct wg_device *wg,
 	peer->ranged_headers = wg->advanced_security &&
 			       (wg->headers[MSGIDX_HANDSHAKE_INIT].start !=
 				wg->headers[MSGIDX_HANDSHAKE_INIT].end);
+	peer->junk_offsets = wg->advanced_security &&
+			     (wg->junk_size[MSGIDX_HANDSHAKE_COOKIE] > 0 ||
+			      wg->junk_size[MSGIDX_TRANSPORT] > 0);
 	wg_noise_handshake_init(&peer->handshake, &wg->static_identity,
 				public_key, preshared_key, peer);
 	peer->internal_id = atomic64_inc_return(&peer_counter);

--- a/src/peer.h
+++ b/src/peer.h
@@ -66,6 +66,7 @@ struct wg_peer {
 	u64 internal_id;
 	atomic_t jp_packet_counter;
 	bool advanced_security;
+	bool ranged_headers;
 };
 
 struct wg_peer *wg_peer_create(struct wg_device *wg,

--- a/src/peer.h
+++ b/src/peer.h
@@ -58,6 +58,7 @@ struct wg_peer {
 	bool timer_need_another_keepalive;
 	bool sent_lastminute_handshake;
 	struct timespec64 walltime_last_handshake;
+	struct timespec64 walltime_last_data;
 	struct kref refcount;
 	struct rcu_head rcu;
 	struct list_head peer_list;

--- a/src/peer.h
+++ b/src/peer.h
@@ -67,6 +67,7 @@ struct wg_peer {
 	atomic_t jp_packet_counter;
 	bool advanced_security;
 	bool ranged_headers;
+	bool junk_offsets;
 };
 
 struct wg_peer *wg_peer_create(struct wg_device *wg,

--- a/src/receive.c
+++ b/src/receive.c
@@ -67,6 +67,20 @@ static size_t prepare_awg_message(struct sk_buff *skb, struct wg_device *wg)
 			skb_push(skb, wg->junk_size[MSGIDX_TRANSPORT]);
 	}
 
+	/* Legacy WireGuard client support: accept standard packets */
+	if (skb->len == MESSAGE_INITIATION_SIZE &&
+	    SKB_TYPE_LE32(skb) == cpu_to_le32(MESSAGE_HANDSHAKE_INITIATION))
+		return MESSAGE_INITIATION_SIZE;
+	if (skb->len == MESSAGE_RESPONSE_SIZE &&
+	    SKB_TYPE_LE32(skb) == cpu_to_le32(MESSAGE_HANDSHAKE_RESPONSE))
+		return MESSAGE_RESPONSE_SIZE;
+	if (skb->len == MESSAGE_COOKIE_REPLY_SIZE &&
+	    SKB_TYPE_LE32(skb) == cpu_to_le32(MESSAGE_HANDSHAKE_COOKIE))
+		return MESSAGE_COOKIE_REPLY_SIZE;
+	if (skb->len >= MESSAGE_MINIMUM_LENGTH &&
+	    SKB_TYPE_LE32(skb) == cpu_to_le32(MESSAGE_DATA))
+		return MESSAGE_TRANSPORT_SIZE;
+
 	net_dbg_skb_ratelimited("%s: Unknown message from %pISpfsc encountered, packet dropped\n",
 								wg->dev->name, skb);
 
@@ -130,7 +144,8 @@ static void wg_receive_handshake_packet(struct wg_device *wg,
 	bool packet_needs_cookie;
 	bool under_load;
 
-	if (mh_validate(SKB_TYPE_LE32(skb), &wg->headers[MSGIDX_HANDSHAKE_COOKIE])) {
+	if (mh_validate(SKB_TYPE_LE32(skb), &wg->headers[MSGIDX_HANDSHAKE_COOKIE]) ||
+	    SKB_TYPE_LE32(skb) == cpu_to_le32(MESSAGE_HANDSHAKE_COOKIE)) {
 		net_dbg_skb_ratelimited("%s: Receiving cookie response from %pISpfsc\n",
 					wg->dev->name, skb);
 		wg_cookie_message_consume(
@@ -160,7 +175,8 @@ static void wg_receive_handshake_packet(struct wg_device *wg,
 		return;
 	}
 
-	if (mh_validate(SKB_TYPE_LE32(skb), &wg->headers[MSGIDX_HANDSHAKE_INIT])) {
+	if (mh_validate(SKB_TYPE_LE32(skb), &wg->headers[MSGIDX_HANDSHAKE_INIT]) ||
+	    SKB_TYPE_LE32(skb) == cpu_to_le32(MESSAGE_HANDSHAKE_INITIATION)) {
 		struct message_handshake_initiation *message =
 			(struct message_handshake_initiation *)skb->data;
 
@@ -181,7 +197,8 @@ static void wg_receive_handshake_packet(struct wg_device *wg,
 				    &peer->endpoint.addr);
 		wg_packet_send_handshake_response(peer);
 	}
-	if (mh_validate(SKB_TYPE_LE32(skb), &wg->headers[MSGIDX_HANDSHAKE_RESPONSE])) {
+	if (mh_validate(SKB_TYPE_LE32(skb), &wg->headers[MSGIDX_HANDSHAKE_RESPONSE]) ||
+	    SKB_TYPE_LE32(skb) == cpu_to_le32(MESSAGE_HANDSHAKE_RESPONSE)) {
 		struct message_handshake_response *message =
 			(struct message_handshake_response *)skb->data;
 
@@ -585,8 +602,11 @@ void wg_packet_receive(struct wg_device *wg, struct sk_buff *skb)
 		goto err;
 
 	if (mh_validate(SKB_TYPE_LE32(skb), &wg->headers[MSGIDX_HANDSHAKE_INIT]) ||
-		mh_validate(SKB_TYPE_LE32(skb), &wg->headers[MSGIDX_HANDSHAKE_RESPONSE]) ||
-		mh_validate(SKB_TYPE_LE32(skb), &wg->headers[MSGIDX_HANDSHAKE_COOKIE])) {
+	    mh_validate(SKB_TYPE_LE32(skb), &wg->headers[MSGIDX_HANDSHAKE_RESPONSE]) ||
+	    mh_validate(SKB_TYPE_LE32(skb), &wg->headers[MSGIDX_HANDSHAKE_COOKIE]) ||
+	    SKB_TYPE_LE32(skb) == cpu_to_le32(MESSAGE_HANDSHAKE_INITIATION) ||
+	    SKB_TYPE_LE32(skb) == cpu_to_le32(MESSAGE_HANDSHAKE_RESPONSE) ||
+	    SKB_TYPE_LE32(skb) == cpu_to_le32(MESSAGE_HANDSHAKE_COOKIE)) {
 		int cpu, ret = -EBUSY;
 
 		if (unlikely(!rng_is_initialized()))
@@ -609,7 +629,8 @@ void wg_packet_receive(struct wg_device *wg, struct sk_buff *skb)
 		/* Queues up a call to packet_process_queued_handshake_packets(skb): */
 		queue_work_on(cpu, wg->handshake_receive_wq,
 			      &per_cpu_ptr(wg->handshake_queue.worker, cpu)->work);
-	} else if (mh_validate(SKB_TYPE_LE32(skb), &wg->headers[MSGIDX_TRANSPORT])) {
+	} else if (mh_validate(SKB_TYPE_LE32(skb), &wg->headers[MSGIDX_TRANSPORT]) ||
+		   SKB_TYPE_LE32(skb) == cpu_to_le32(MESSAGE_DATA)) {
 		PACKET_CB(skb)->ds = ip_tunnel_get_dsfield(ip_hdr(skb), skb);
 		wg_packet_consume_data(wg, skb);
 	} else {

--- a/src/receive.c
+++ b/src/receive.c
@@ -474,6 +474,7 @@ static void wg_packet_consume_data_done(struct wg_peer *peer,
 		goto dishonest_packet_peer;
 
 	napi_gro_receive(&peer->napi, skb);
+	ktime_get_coarse_real_ts64(&peer->walltime_last_data);
 	update_rx_stats(peer, message_data_len(len_before_trim));
 	return;
 

--- a/src/receive.c
+++ b/src/receive.c
@@ -27,14 +27,15 @@ static void update_rx_stats(struct wg_peer *peer, size_t len)
 	peer->rx_bytes += len;
 }
 
-static size_t prepare_awg_message(struct sk_buff *skb, struct wg_device *wg)
+static size_t prepare_awg_message(struct sk_buff *skb, struct wg_device *wg,
+				  bool *had_junk_offsets)
 {
 	if (skb_is_nonlinear(skb) && unlikely(skb_linearize(skb))) {
 		net_dbg_skb_ratelimited("%s: non-linear sk_buff from %pISpfsc could not be linearized, dropping packet\n",
 								wg->dev->name, skb);
 		return 0;
 	}
-	
+
 	if (skb->len == wg->junk_size[MSGIDX_HANDSHAKE_INIT] + MESSAGE_INITIATION_SIZE) {
 		skb_pull(skb, wg->junk_size[MSGIDX_HANDSHAKE_INIT]);
 		if (mh_validate(SKB_TYPE_LE32(skb), &wg->headers[MSGIDX_HANDSHAKE_INIT]))
@@ -54,17 +55,34 @@ static size_t prepare_awg_message(struct sk_buff *skb, struct wg_device *wg)
 	if (skb->len == wg->junk_size[MSGIDX_HANDSHAKE_COOKIE] + MESSAGE_COOKIE_REPLY_SIZE) {
 		skb_pull(skb, wg->junk_size[MSGIDX_HANDSHAKE_COOKIE]);
 		if (mh_validate(SKB_TYPE_LE32(skb), &wg->headers[MSGIDX_HANDSHAKE_COOKIE]))
-			return MESSAGE_HANDSHAKE_COOKIE;
+			return MESSAGE_COOKIE_REPLY_SIZE;
 		else
 			skb_push(skb, wg->junk_size[MSGIDX_HANDSHAKE_COOKIE]);
 	}
 
 	if (skb->len >= wg->junk_size[MSGIDX_TRANSPORT] + MESSAGE_TRANSPORT_SIZE) {
 		skb_pull(skb, wg->junk_size[MSGIDX_TRANSPORT]);
-		if (mh_validate(SKB_TYPE_LE32(skb), &wg->headers[MSGIDX_TRANSPORT]))
+		if (mh_validate(SKB_TYPE_LE32(skb), &wg->headers[MSGIDX_TRANSPORT])) {
+			*had_junk_offsets = true;
 			return MESSAGE_TRANSPORT_SIZE;
-		else
+		} else
 			skb_push(skb, wg->junk_size[MSGIDX_TRANSPORT]);
+	}
+
+	/* AWG peer without S3-S4 junk offsets: try AWG headers at standard
+	 * offsets. Only needed when server has S3/S4 configured, otherwise
+	 * the blocks above already handle this (strip 0 bytes = no-op).
+	 */
+	if (wg->junk_size[MSGIDX_HANDSHAKE_COOKIE] > 0 &&
+	    skb->len == MESSAGE_COOKIE_REPLY_SIZE &&
+	    mh_validate(SKB_TYPE_LE32(skb), &wg->headers[MSGIDX_HANDSHAKE_COOKIE]))
+		return MESSAGE_COOKIE_REPLY_SIZE;
+
+	if (wg->junk_size[MSGIDX_TRANSPORT] > 0 &&
+	    skb->len >= MESSAGE_MINIMUM_LENGTH &&
+	    mh_validate(SKB_TYPE_LE32(skb), &wg->headers[MSGIDX_TRANSPORT])) {
+		*had_junk_offsets = false;
+		return MESSAGE_TRANSPORT_SIZE;
 	}
 
 	/* Legacy WireGuard client support: accept standard packets */
@@ -87,7 +105,8 @@ static size_t prepare_awg_message(struct sk_buff *skb, struct wg_device *wg)
 	return 0;
 }
 
-static int prepare_skb_header(struct sk_buff *skb, struct wg_device *wg)
+static int prepare_skb_header(struct sk_buff *skb, struct wg_device *wg,
+			      bool *had_junk_offsets)
 {
 	size_t data_offset, data_len, header_len;
 	struct udphdr *udp;
@@ -122,7 +141,7 @@ static int prepare_skb_header(struct sk_buff *skb, struct wg_device *wg)
 	if (unlikely(skb->len != data_len))
 		/* Final len does not agree with calculated len */
 		return -EINVAL;
-	header_len = prepare_awg_message(skb, wg);
+	header_len = prepare_awg_message(skb, wg, had_junk_offsets);
 	if (unlikely(!header_len))
 		return -EINVAL;
 	__skb_push(skb, data_offset);
@@ -563,7 +582,8 @@ void wg_packet_decrypt_worker(struct work_struct *work)
 #endif
 }
 
-static void wg_packet_consume_data(struct wg_device *wg, struct sk_buff *skb)
+static void wg_packet_consume_data(struct wg_device *wg, struct sk_buff *skb,
+				   bool had_junk_offsets)
 {
 	__le32 idx = ((struct message_data *)skb->data)->key_idx;
 	struct wg_peer *peer = NULL;
@@ -579,6 +599,17 @@ static void wg_packet_consume_data(struct wg_device *wg, struct sk_buff *skb)
 
 	if (unlikely(READ_ONCE(peer->is_dead)))
 		goto err;
+
+	if (peer->advanced_security) {
+		if (had_junk_offsets)
+			peer->junk_offsets = true;
+		else if (skb->len > MESSAGE_MINIMUM_LENGTH)
+			peer->junk_offsets = false;
+		/* Keepalives (skb->len == MESSAGE_MINIMUM_LENGTH) without
+		 * S4 junk don't trigger downgrade — some implementations
+		 * omit S4 junk from keepalive packets.
+		 */
+	}
 
 	ret = wg_queue_enqueue_per_device_and_peer(&wg->decrypt_queue, &peer->rx_queue, skb,
 						   wg->packet_crypt_wq);
@@ -598,7 +629,9 @@ err_keypair:
 
 void wg_packet_receive(struct wg_device *wg, struct sk_buff *skb)
 {
-	if (unlikely(prepare_skb_header(skb, wg) < 0))
+	bool had_junk_offsets = false;
+
+	if (unlikely(prepare_skb_header(skb, wg, &had_junk_offsets) < 0))
 		goto err;
 
 	if (mh_validate(SKB_TYPE_LE32(skb), &wg->headers[MSGIDX_HANDSHAKE_INIT]) ||
@@ -632,7 +665,7 @@ void wg_packet_receive(struct wg_device *wg, struct sk_buff *skb)
 	} else if (mh_validate(SKB_TYPE_LE32(skb), &wg->headers[MSGIDX_TRANSPORT]) ||
 		   SKB_TYPE_LE32(skb) == cpu_to_le32(MESSAGE_DATA)) {
 		PACKET_CB(skb)->ds = ip_tunnel_get_dsfield(ip_hdr(skb), skb);
-		wg_packet_consume_data(wg, skb);
+		wg_packet_consume_data(wg, skb, had_junk_offsets);
 	} else {
 		WARN(1, "Non-exhaustive parsing of packet header lead to unknown packet type!\n");
 		goto err;

--- a/src/send.c
+++ b/src/send.c
@@ -43,46 +43,52 @@ static void wg_packet_send_handshake_initiation(struct wg_peer *peer)
 			    peer->device->dev->name, peer->internal_id,
 			    &peer->endpoint.addr);
 
-	atomic_set(&peer->jp_packet_counter, get_random_u32());
-	for (i = 0; i < ARRAY_SIZE(wg->ispecs); ++i)
-	{
-		spec = &wg->ispecs[i];
-		if (spec->pkt_size > 0) {
-			mutex_lock(&spec->lock);
-			jp_spec_applymods(spec, peer);
-			wg_socket_send_buffer_to_peer(peer, spec->pkt, spec->pkt_size, 0, 0);
-			atomic_inc(&peer->jp_packet_counter);
-			mutex_unlock(&spec->lock);
-		}
-	}
-	
-	if (wg->jc && wg->jmax) {
-		net_dbg_ratelimited("%s: Sending dummy junk packets to %llu (%pISpfsc)\n",
-			    peer->device->dev->name, peer->internal_id,
-			    &peer->endpoint.addr);
-
-		junk_packet_count = wg->jc;
-		buffer = kzalloc(wg->jmax, GFP_KERNEL);
-
-		while (junk_packet_count-- > 0) {
-			junk_packet_size = (u16) get_random_u32_inclusive(wg->jmin, wg->jmax);
-
-			get_random_bytes(buffer, junk_packet_size);
-			get_random_bytes(&ds, 1);
-			wg_socket_send_buffer_to_peer(peer, buffer, junk_packet_size, ds, 0);
+	if (peer->advanced_security) {
+		atomic_set(&peer->jp_packet_counter, get_random_u32());
+		for (i = 0; i < ARRAY_SIZE(wg->ispecs); ++i) {
+			spec = &wg->ispecs[i];
+			if (spec->pkt_size > 0) {
+				mutex_lock(&spec->lock);
+				jp_spec_applymods(spec, peer);
+				wg_socket_send_buffer_to_peer(peer, spec->pkt, spec->pkt_size, 0, 0);
+				atomic_inc(&peer->jp_packet_counter);
+				mutex_unlock(&spec->lock);
+			}
 		}
 
-		kfree(buffer);
+		if (wg->jc && wg->jmax) {
+			net_dbg_ratelimited("%s: Sending dummy junk packets to %llu (%pISpfsc)\n",
+					    peer->device->dev->name, peer->internal_id,
+					    &peer->endpoint.addr);
+
+			junk_packet_count = wg->jc;
+			buffer = kzalloc(wg->jmax, GFP_KERNEL);
+
+			while (junk_packet_count-- > 0) {
+				junk_packet_size = (u16) get_random_u32_inclusive(wg->jmin, wg->jmax);
+
+				get_random_bytes(buffer, junk_packet_size);
+				get_random_bytes(&ds, 1);
+				wg_socket_send_buffer_to_peer(peer, buffer, junk_packet_size, ds, 0);
+			}
+
+			kfree(buffer);
+		}
 	}
 
-	if (wg_noise_handshake_create_initiation(&packet, &peer->handshake, mh_genheader(&wg->headers[MSGIDX_HANDSHAKE_INIT]))) {
+	if (wg_noise_handshake_create_initiation(&packet, &peer->handshake,
+			peer->advanced_security ?
+			mh_genheader(&wg->headers[MSGIDX_HANDSHAKE_INIT]) :
+			MESSAGE_HANDSHAKE_INITIATION)) {
 		wg_cookie_add_mac_to_packet(&packet, sizeof(packet), peer);
 		wg_timers_any_authenticated_packet_traversal(peer);
 		wg_timers_any_authenticated_packet_sent(peer);
 		atomic64_set(&peer->last_sent_handshake,
 			     ktime_get_coarse_boottime_ns());
 		wg_socket_send_buffer_to_peer(peer, &packet, sizeof(packet),
-					      HANDSHAKE_DSCP, wg->junk_size[MSGIDX_HANDSHAKE_INIT]);
+					      HANDSHAKE_DSCP,
+					      peer->advanced_security ?
+					      wg->junk_size[MSGIDX_HANDSHAKE_INIT] : 0);
 		wg_timers_handshake_initiated(peer);
 	}
 }
@@ -136,7 +142,10 @@ void wg_packet_send_handshake_response(struct wg_peer *peer)
 			    peer->device->dev->name, peer->internal_id,
 			    &peer->endpoint.addr);
 
-	if (wg_noise_handshake_create_response(&packet, &peer->handshake, mh_genheader(&wg->headers[MSGIDX_HANDSHAKE_RESPONSE]))) {
+	if (wg_noise_handshake_create_response(&packet, &peer->handshake,
+			peer->advanced_security ?
+			mh_genheader(&wg->headers[MSGIDX_HANDSHAKE_RESPONSE]) :
+			MESSAGE_HANDSHAKE_RESPONSE)) {
 		wg_cookie_add_mac_to_packet(&packet, sizeof(packet), peer);
 		if (wg_noise_handshake_begin_session(&peer->handshake,
 						     &peer->keypairs)) {
@@ -148,7 +157,8 @@ void wg_packet_send_handshake_response(struct wg_peer *peer)
 			wg_socket_send_buffer_to_peer(peer, &packet,
 						      sizeof(packet),
 						      HANDSHAKE_DSCP,
-							  wg->junk_size[MSGIDX_HANDSHAKE_RESPONSE]);
+						      peer->advanced_security ?
+						      wg->junk_size[MSGIDX_HANDSHAKE_RESPONSE] : 0);
 		}
 	}
 }
@@ -161,12 +171,21 @@ void wg_packet_send_handshake_cookie(struct wg_device *wg,
 
 	net_dbg_skb_ratelimited("%s: Sending cookie response for denied handshake message for %pISpfsc\n",
 				wg->dev->name, initiating_skb);
-	wg_cookie_message_create(&packet, initiating_skb, sender_index,
-				 &wg->cookie_checker,
-				 mh_genheader(&wg->headers[MSGIDX_HANDSHAKE_COOKIE]));
-	wg_socket_send_buffer_as_reply_to_skb(wg, initiating_skb, &packet,
-					      sizeof(packet),
-						  wg->junk_size[MSGIDX_HANDSHAKE_COOKIE]);
+	if (SKB_TYPE_LE32(initiating_skb) == cpu_to_le32(MESSAGE_HANDSHAKE_INITIATION) ||
+	    SKB_TYPE_LE32(initiating_skb) == cpu_to_le32(MESSAGE_HANDSHAKE_RESPONSE)) {
+		wg_cookie_message_create(&packet, initiating_skb, sender_index,
+					 &wg->cookie_checker,
+					 MESSAGE_HANDSHAKE_COOKIE);
+		wg_socket_send_buffer_as_reply_to_skb(wg, initiating_skb,
+						      &packet, sizeof(packet), 0);
+	} else {
+		wg_cookie_message_create(&packet, initiating_skb, sender_index,
+					 &wg->cookie_checker,
+					 mh_genheader(&wg->headers[MSGIDX_HANDSHAKE_COOKIE]));
+		wg_socket_send_buffer_as_reply_to_skb(wg, initiating_skb,
+						      &packet, sizeof(packet),
+						      wg->junk_size[MSGIDX_HANDSHAKE_COOKIE]);
+	}
 }
 
 static void keep_key_fresh(struct wg_peer *peer)
@@ -354,8 +373,11 @@ void wg_packet_encrypt_worker(struct work_struct *work)
 			wg = PACKET_PEER(first)->device;
 
 			if (likely(encrypt_packet(
-						  mh_genheader(&wg->headers[MSGIDX_TRANSPORT]),
-						  wg->junk_size[MSGIDX_TRANSPORT],
+						  PACKET_PEER(first)->advanced_security ?
+						  mh_genheader(&wg->headers[MSGIDX_TRANSPORT]) :
+						  MESSAGE_DATA,
+						  PACKET_PEER(first)->advanced_security ?
+						  wg->junk_size[MSGIDX_TRANSPORT] : 0,
 						  skb,
 						  PACKET_CB(first)->keypair
 						  COMPAT_MAYBE_SIMD_CONTEXT(&simd_context)))) {

--- a/src/send.c
+++ b/src/send.c
@@ -78,7 +78,8 @@ static void wg_packet_send_handshake_initiation(struct wg_peer *peer)
 
 	if (wg_noise_handshake_create_initiation(&packet, &peer->handshake,
 			peer->advanced_security ?
-			mh_genheader(&wg->headers[MSGIDX_HANDSHAKE_INIT]) :
+			mh_peerheader(&wg->headers[MSGIDX_HANDSHAKE_INIT],
+				      peer->ranged_headers) :
 			MESSAGE_HANDSHAKE_INITIATION)) {
 		wg_cookie_add_mac_to_packet(&packet, sizeof(packet), peer);
 		wg_timers_any_authenticated_packet_traversal(peer);
@@ -144,7 +145,8 @@ void wg_packet_send_handshake_response(struct wg_peer *peer)
 
 	if (wg_noise_handshake_create_response(&packet, &peer->handshake,
 			peer->advanced_security ?
-			mh_genheader(&wg->headers[MSGIDX_HANDSHAKE_RESPONSE]) :
+			mh_peerheader(&wg->headers[MSGIDX_HANDSHAKE_RESPONSE],
+				      peer->ranged_headers) :
 			MESSAGE_HANDSHAKE_RESPONSE)) {
 		wg_cookie_add_mac_to_packet(&packet, sizeof(packet), peer);
 		if (wg_noise_handshake_begin_session(&peer->handshake,
@@ -168,24 +170,41 @@ void wg_packet_send_handshake_cookie(struct wg_device *wg,
 				     __le32 sender_index)
 {
 	struct message_handshake_cookie packet;
+	__le32 type = SKB_TYPE_LE32(initiating_skb);
+	u32 host_type = le32_to_cpu(type);
+	bool is_legacy, is_ranged;
+	u32 cookie_header;
+	size_t cookie_junk;
+
+	is_legacy = (type == cpu_to_le32(MESSAGE_HANDSHAKE_INITIATION) ||
+		     type == cpu_to_le32(MESSAGE_HANDSHAKE_RESPONSE));
+
+	/* Detect AWG 2.0 vs 1.0: if the incoming header is not at the
+	 * start of its range, the peer must support ranged headers.
+	 */
+	is_ranged = false;
+	if (!is_legacy) {
+		if (mh_validate(type, &wg->headers[MSGIDX_HANDSHAKE_INIT]))
+			is_ranged = (host_type != wg->headers[MSGIDX_HANDSHAKE_INIT].start);
+		else if (mh_validate(type, &wg->headers[MSGIDX_HANDSHAKE_RESPONSE]))
+			is_ranged = (host_type != wg->headers[MSGIDX_HANDSHAKE_RESPONSE].start);
+	}
+
+	if (is_legacy) {
+		cookie_header = MESSAGE_HANDSHAKE_COOKIE;
+		cookie_junk = 0;
+	} else {
+		cookie_header = mh_peerheader(&wg->headers[MSGIDX_HANDSHAKE_COOKIE],
+					      is_ranged);
+		cookie_junk = wg->junk_size[MSGIDX_HANDSHAKE_COOKIE];
+	}
 
 	net_dbg_skb_ratelimited("%s: Sending cookie response for denied handshake message for %pISpfsc\n",
 				wg->dev->name, initiating_skb);
-	if (SKB_TYPE_LE32(initiating_skb) == cpu_to_le32(MESSAGE_HANDSHAKE_INITIATION) ||
-	    SKB_TYPE_LE32(initiating_skb) == cpu_to_le32(MESSAGE_HANDSHAKE_RESPONSE)) {
-		wg_cookie_message_create(&packet, initiating_skb, sender_index,
-					 &wg->cookie_checker,
-					 MESSAGE_HANDSHAKE_COOKIE);
-		wg_socket_send_buffer_as_reply_to_skb(wg, initiating_skb,
-						      &packet, sizeof(packet), 0);
-	} else {
-		wg_cookie_message_create(&packet, initiating_skb, sender_index,
-					 &wg->cookie_checker,
-					 mh_genheader(&wg->headers[MSGIDX_HANDSHAKE_COOKIE]));
-		wg_socket_send_buffer_as_reply_to_skb(wg, initiating_skb,
-						      &packet, sizeof(packet),
-						      wg->junk_size[MSGIDX_HANDSHAKE_COOKIE]);
-	}
+	wg_cookie_message_create(&packet, initiating_skb, sender_index,
+				 &wg->cookie_checker, cookie_header);
+	wg_socket_send_buffer_as_reply_to_skb(wg, initiating_skb,
+					      &packet, sizeof(packet), cookie_junk);
 }
 
 static void keep_key_fresh(struct wg_peer *peer)
@@ -374,7 +393,8 @@ void wg_packet_encrypt_worker(struct work_struct *work)
 
 			if (likely(encrypt_packet(
 						  PACKET_PEER(first)->advanced_security ?
-						  mh_genheader(&wg->headers[MSGIDX_TRANSPORT]) :
+						  mh_peerheader(&wg->headers[MSGIDX_TRANSPORT],
+								PACKET_PEER(first)->ranged_headers) :
 						  MESSAGE_DATA,
 						  PACKET_PEER(first)->advanced_security ?
 						  wg->junk_size[MSGIDX_TRANSPORT] : 0,

--- a/src/send.c
+++ b/src/send.c
@@ -396,7 +396,8 @@ void wg_packet_encrypt_worker(struct work_struct *work)
 						  mh_peerheader(&wg->headers[MSGIDX_TRANSPORT],
 								PACKET_PEER(first)->ranged_headers) :
 						  MESSAGE_DATA,
-						  PACKET_PEER(first)->advanced_security ?
+						  (PACKET_PEER(first)->advanced_security &&
+						   PACKET_PEER(first)->junk_offsets) ?
 						  wg->junk_size[MSGIDX_TRANSPORT] : 0,
 						  skb,
 						  PACKET_CB(first)->keypair

--- a/src/uapi/wireguard.h
+++ b/src/uapi/wireguard.h
@@ -118,6 +118,9 @@
  *            WGPEER_A_ADVANCED_SECURITY: flag indicating that advanced security
  *                                       techniques provided by AmneziaWG should
  *                                       be used.
+ *            WGPEER_A_RANGED_HEADERS: flag indicating that the peer supports
+ *                                     ranged (AWG 2.0) magic headers rather
+ *                                     than fixed (AWG 1.0) values.
  *        0: NLA_NESTED
  *            ...
  *        ...
@@ -228,6 +231,7 @@ enum wgpeer_attribute {
 	WGPEER_A_ALLOWEDIPS,
 	WGPEER_A_PROTOCOL_VERSION,
 	WGPEER_A_ADVANCED_SECURITY,
+	WGPEER_A_RANGED_HEADERS,
 	__WGPEER_A_LAST
 };
 #define WGPEER_A_MAX (__WGPEER_A_LAST - 1)

--- a/src/uapi/wireguard.h
+++ b/src/uapi/wireguard.h
@@ -121,6 +121,9 @@
  *            WGPEER_A_RANGED_HEADERS: flag indicating that the peer supports
  *                                     ranged (AWG 2.0) magic headers rather
  *                                     than fixed (AWG 1.0) values.
+ *            WGPEER_A_JUNK_OFFSETS: flag indicating that the peer uses S3-S4
+ *                                   junk padding on cookie and transport
+ *                                   packets.
  *        0: NLA_NESTED
  *            ...
  *        ...
@@ -232,6 +235,7 @@ enum wgpeer_attribute {
 	WGPEER_A_PROTOCOL_VERSION,
 	WGPEER_A_ADVANCED_SECURITY,
 	WGPEER_A_RANGED_HEADERS,
+	WGPEER_A_JUNK_OFFSETS,
 	__WGPEER_A_LAST
 };
 #define WGPEER_A_MAX (__WGPEER_A_LAST - 1)

--- a/src/uapi/wireguard.h
+++ b/src/uapi/wireguard.h
@@ -124,6 +124,13 @@
  *            WGPEER_A_JUNK_OFFSETS: flag indicating that the peer uses S3-S4
  *                                   junk padding on cookie and transport
  *                                   packets.
+ *            WGPEER_A_LAST_DATA_TIME: struct __kernel_timespec, wall clock
+ *                                     time of last successfully decrypted
+ *                                     non-keepalive data packet from this
+ *                                     peer. Zero if no data received yet.
+ *                                     Compare with WGPEER_A_LAST_HANDSHAKE_TIME
+ *                                     to determine if junk_offsets has been
+ *                                     confirmed since the last handshake.
  *        0: NLA_NESTED
  *            ...
  *        ...
@@ -236,6 +243,7 @@ enum wgpeer_attribute {
 	WGPEER_A_ADVANCED_SECURITY,
 	WGPEER_A_RANGED_HEADERS,
 	WGPEER_A_JUNK_OFFSETS,
+	WGPEER_A_LAST_DATA_TIME,
 	__WGPEER_A_LAST
 };
 #define WGPEER_A_MAX (__WGPEER_A_LAST - 1)


### PR DESCRIPTION
## Summary

When an AWG 2.0 server has S3-S4 junk offsets configured (S3>0, S4>0), it prepends S3/S4 junk to cookie and transport packets for all AWG peers unconditionally. This breaks AWG clients that don't use S3-S4 offsets — they can't find the header at the expected offset and drop the packet.

This PR adds per-peer detection of S3-S4 junk offset support, following the established pattern of `advanced_security` (#164) and `ranged_headers` (#165):

- Add `junk_offsets` field to `struct wg_peer`
- In `prepare_awg_message()`, add fallback parsing: try AWG headers at standard offsets (without S3/S4 prefix) when the S3/S4-prefixed match fails
- Thread detection result via function arguments to `wg_packet_consume_data()`, which updates `peer->junk_offsets` after peer identification via `key_idx`
- Gate S4 junk in `wg_packet_encrypt_worker` on `peer->advanced_security && peer->junk_offsets`
- Only downgrade `junk_offsets` from true to false on real data packets (`skb->len > MESSAGE_MINIMUM_LENGTH`), not keepalives — some client implementations (notably wireguard-go based) omit S4 junk from keepalive packets while correctly adding it to data packets
- Cookie S3 path left unchanged — no peer context during cookie send, failure mode is benign (rare, temporary)
- S1/S2 paths left unchanged — #164 already handles it

### Transient packet loss while switching to legacy mode

Because the handshake carries no information about whether the client supports S3/S4, the server cannot know the peer's capability until it observes actual transport packets. New peers optimistically inherit junk_offsets = true from the device configuration. When a client without S3/S4 connects, this creates a brief detection window:

1. Handshake completes successfully (unaffected by S3/S4)
2. Server sends transport data with S4 junk prefix — client cannot parse it and drops the packet
3. Client sends its own transport data without S4 junk prefix — server's fallback parsing accepts it and sets peer->junk_offsets = false
4. Server now sends without S4 junk — communication proceeds normally

During the step 2, server-to-client packets are dropped.

There is no workaround for this within the current design — S3/S4 junk is a transport-layer feature invisible at handshake time. However, this is a very minor issue in practice for several reasons:

- The primary mode is unaffected. When the client matches the server's S3/S4 configuration (the expected deployment), junk_offsets is correctly true from the start and no packets are dropped.
- Only the fallback mode is affected — specifically, AWG clients that lack S3/S4 support connecting to a server that has S3/S4 configured. Without this PR, that scenario doesn't work at all (every packet is dropped indefinitely). A brief detection window that self-resolves with the first data packet received from the client is strictly better than permanent failure.
- Client is usually first to communicate — in most real life scenarios the issue is non-existent.

### UAPI extension

Expose the new flag to userspace via `WGPEER_A_JUNK_OFFSETS` netlink attribute (backward compatible — old userspace ignores unknown attributes). Combined with the existing flags, userspace can now fully distinguish peer capabilities:

| `advanced_security` | `ranged_headers` | `junk_offsets` | Peer type |
|---|---|---|---|
| false | - | - | Legacy WireGuard |
| true | false | false | AWG 1.0 (fixed headers, no S3-S4) |
| true | false | true | AWG 1.0 (fixed headers, with S3-S4) |
| true | true | false | AWG 2.0 (ranged headers, no S3-S4) |
| true | true | true | AWG 2.0 (ranged headers, with S3-S4) |

**Depends on #165** — must be merged first.

## Test plan

- [x] AWG client without S3-S4 connects to AWG server with S3-S4 configured
- [x] AWG client with S3-S4 connects to AWG server with S3-S4 configured
- [x] Legacy WireGuard client still connects (unchanged from #164)
- [x] AWG 1.0 client (fixed headers) still connects (unchanged from #165)
- [x] Userspace can read `WGPEER_A_JUNK_OFFSETS` attribute for connected peers
- [x] Client mode not broken — clients follow their own device configuration

Closes #168