### PR TITLE
build: move pr_fmt definition from Kbuild to source files

### DIFF
--- a/src/Kbuild
+++ b/src/Kbuild
@@ -2,7 +2,6 @@
 #
 # Copyright (C) 2015-2019 Jason A. Donenfeld <Jason@zx2c4.com>. All Rights Reserved.
 
-ccflags-y := -D'pr_fmt(fmt)=KBUILD_MODNAME ": " fmt'
 ccflags-y += -Wframe-larger-than=2048
 ccflags-$(CONFIG_AMNEZIAWG_DEBUG) += -DDEBUG -g
 ccflags-$(if $(WIREGUARD_VERSION),y,) += -D'WIREGUARD_VERSION="$(WIREGUARD_VERSION)"'

--- a/src/allowedips.c
+++ b/src/allowedips.c
@@ -2,7 +2,7 @@
 /*
  * Copyright (C) 2015-2019 Jason A. Donenfeld <Jason@zx2c4.com>. All Rights Reserved.
  */
-
+#define pr_fmt(fmt) KBUILD_MODNAME ": " fmt
 #include "allowedips.h"
 #include "peer.h"
 

--- a/src/cookie.c
+++ b/src/cookie.c
@@ -2,7 +2,7 @@
 /*
  * Copyright (C) 2015-2019 Jason A. Donenfeld <Jason@zx2c4.com>. All Rights Reserved.
  */
-
+#define pr_fmt(fmt) KBUILD_MODNAME ": " fmt
 #include "cookie.h"
 #include "peer.h"
 #include "device.h"

--- a/src/device.c
+++ b/src/device.c
@@ -2,7 +2,7 @@
 /*
  * Copyright (C) 2015-2019 Jason A. Donenfeld <Jason@zx2c4.com>. All Rights Reserved.
  */
-
+#define pr_fmt(fmt) KBUILD_MODNAME ": " fmt
 #include "junk.h"
 #include "queueing.h"
 #include "socket.h"

--- a/src/junk.c
+++ b/src/junk.c
@@ -1,3 +1,4 @@
+#define pr_fmt(fmt) KBUILD_MODNAME ": " fmt
 #include "junk.h"
 #include "messages.h"
 #include "peer.h"

--- a/src/magic_header.c
+++ b/src/magic_header.c
@@ -1,3 +1,4 @@
+#define pr_fmt(fmt) KBUILD_MODNAME ": " fmt
 #include "magic_header.h"
 
 #include <linux/string.h>

--- a/src/main.c
+++ b/src/main.c
@@ -3,7 +3,7 @@
  * Copyright (C) 2015-2019 Jason A. Donenfeld <Jason@zx2c4.com>. All Rights Reserved.
  * Copyright (C) 2024 AmneziaVPN <admin@amnezia.org>. All Rights Reserved.
  */
-
+#define pr_fmt(fmt) KBUILD_MODNAME ": " fmt
 #include "version.h"
 #include "device.h"
 #include "noise.h"

--- a/src/netlink.c
+++ b/src/netlink.c
@@ -2,7 +2,7 @@
 /*
  * Copyright (C) 2015-2019 Jason A. Donenfeld <Jason@zx2c4.com>. All Rights Reserved.
  */
-
+#define pr_fmt(fmt) KBUILD_MODNAME ": " fmt
 #include "netlink.h"
 #include "device.h"
 #include "magic_header.h"

--- a/src/noise.c
+++ b/src/noise.c
@@ -2,7 +2,7 @@
 /*
  * Copyright (C) 2015-2019 Jason A. Donenfeld <Jason@zx2c4.com>. All Rights Reserved.
  */
-
+#define pr_fmt(fmt) KBUILD_MODNAME ": " fmt
 #include "noise.h"
 #include "device.h"
 #include "magic_header.h"

--- a/src/peer.c
+++ b/src/peer.c
@@ -2,7 +2,7 @@
 /*
  * Copyright (C) 2015-2019 Jason A. Donenfeld <Jason@zx2c4.com>. All Rights Reserved.
  */
-
+#define pr_fmt(fmt) KBUILD_MODNAME ": " fmt
 #include "peer.h"
 #include "device.h"
 #include "queueing.h"

--- a/src/peerlookup.c
+++ b/src/peerlookup.c
@@ -2,7 +2,7 @@
 /*
  * Copyright (C) 2015-2019 Jason A. Donenfeld <Jason@zx2c4.com>. All Rights Reserved.
  */
-
+#define pr_fmt(fmt) KBUILD_MODNAME ": " fmt
 #include "peerlookup.h"
 #include "peer.h"
 #include "noise.h"

--- a/src/queueing.c
+++ b/src/queueing.c
@@ -2,7 +2,7 @@
 /*
  * Copyright (C) 2015-2019 Jason A. Donenfeld <Jason@zx2c4.com>. All Rights Reserved.
  */
-
+#define pr_fmt(fmt) KBUILD_MODNAME ": " fmt
 #include "queueing.h"
 #include <linux/skb_array.h>
 

--- a/src/ratelimiter.c
+++ b/src/ratelimiter.c
@@ -2,7 +2,7 @@
 /*
  * Copyright (C) 2015-2019 Jason A. Donenfeld <Jason@zx2c4.com>. All Rights Reserved.
  */
-
+#define pr_fmt(fmt) KBUILD_MODNAME ": " fmt
 #ifdef COMPAT_CANNOT_DEPRECIATE_BH_RCU
 /* We normally alias all non-_bh functions to the _bh ones in the compat layer,
  * but that's not appropriate here, where we actually do want non-_bh ones.

--- a/src/receive.c
+++ b/src/receive.c
@@ -2,7 +2,7 @@
 /*
  * Copyright (C) 2015-2019 Jason A. Donenfeld <Jason@zx2c4.com>. All Rights Reserved.
  */
-
+#define pr_fmt(fmt) KBUILD_MODNAME ": " fmt
 #include "queueing.h"
 #include "device.h"
 #include "peer.h"

--- a/src/send.c
+++ b/src/send.c
@@ -2,7 +2,7 @@
 /*
  * Copyright (C) 2015-2019 Jason A. Donenfeld <Jason@zx2c4.com>. All Rights Reserved.
  */
-
+#define pr_fmt(fmt) KBUILD_MODNAME ": " fmt
 #include "junk.h"
 #include "magic_header.h"
 #include "queueing.h"

--- a/src/socket.c
+++ b/src/socket.c
@@ -2,7 +2,7 @@
 /*
  * Copyright (C) 2015-2019 Jason A. Donenfeld <Jason@zx2c4.com>. All Rights Reserved.
  */
-
+#define pr_fmt(fmt) KBUILD_MODNAME ": " fmt
 #include "device.h"
 #include "peer.h"
 #include "socket.h"

--- a/src/timers.c
+++ b/src/timers.c
@@ -2,7 +2,7 @@
 /*
  * Copyright (C) 2015-2019 Jason A. Donenfeld <Jason@zx2c4.com>. All Rights Reserved.
  */
-
+#define pr_fmt(fmt) KBUILD_MODNAME ": " fmt
 #include "timers.h"
 #include "device.h"
 #include "peer.h"


### PR DESCRIPTION
7.0.9 fails to handle command-line definition of pr_fmt

    -D'pr_fmt(fmt)=KBUILD_MODNAME ": " fmt'

with the errors looking like:

    gcc: error: ":: linker input file not found

Define pr_fmt locally in source files instead, it fixes the issue.