### PR TITLE
socket: fix build with linux 7.1

### DIFF
--- a/src/compat/compat.h
+++ b/src/compat/compat.h
@@ -1407,4 +1407,12 @@ static inline char *nla_strdup(const struct nlattr *nla, gfp_t flags)
 	blake2s(out, in, key, outlen, inlen, keylen)
 #endif
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(7, 1, 0) && !IS_ENABLED(CONFIG_IPV6)
+#include <net/ipv6_stubs.h>
+static inline struct dst_entry *ip6_dst_lookup_flow(struct net *net, const struct sock *sk, struct flowi6 *fl6,
+				      const struct in6_addr *final_dst) {
+	return ipv6_stub->ipv6_dst_lookup_flow(net, sk, fl6, final_dst);
+}
+#endif
+
 #endif /* _WG_COMPAT_H */

--- a/src/socket.c
+++ b/src/socket.c
@@ -136,8 +136,7 @@ static int send6(struct wg_device *wg, struct sk_buff *skb,
 			if (cache)
 				dst_cache_reset(cache);
 		}
-		dst = ipv6_stub->ipv6_dst_lookup_flow(sock_net(sock), sock, &fl,
-						      NULL);
+		dst = ip6_dst_lookup_flow(sock_net(sock), sock, &fl, NULL);
 		if (IS_ERR(dst)) {
 			ret = PTR_ERR(dst);
 			net_dbg_ratelimited("%s: No route to %pISpfsc, error %d\n",


### PR DESCRIPTION
This also works for older kernels with CONFIG_IPV6=y, but will break if CONFIG_IPV6=m, but I'm not sure that's worth supporting as every distro I know of has shipped =y since forever.