### PR TITLE
compat: use ip6_dst_lookup_flow on kernels >= 7.1

### DIFF
--- a/src/compat/compat.h
+++ b/src/compat/compat.h
@@ -1302,10 +1302,6 @@ static inline int timer_delete(struct timer_list *timer)
 }
 #endif
 
-#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 16, 0)
-#define timer_container_of from_timer
-#endif
-
 #if LINUX_VERSION_CODE < KERNEL_VERSION(6, 17, 0)
 #include <linux/in6.h>
 struct sockaddr_inet {
@@ -1315,7 +1311,7 @@ struct sockaddr_inet {
 };
 #endif
 
-#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 17, 0)
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 12, 0)
 #include <linux/netdevice.h>
 static inline void netif_threaded_enable(struct net_device *dev) { }
 #endif

--- a/src/compat/compat.h
+++ b/src/compat/compat.h
@@ -92,6 +92,12 @@
 #define ipv6_dst_lookup_flow(a, b, c, d) ipv6_dst_lookup(a, b, &dst, c) + (void *)0 ?: dst
 #endif
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(7, 1, 0)
+#define wg_ipv6_dst_lookup_flow(a, b, c, d) ip6_dst_lookup_flow(a, b, c, d)
+#else
+#define wg_ipv6_dst_lookup_flow(a, b, c, d) ipv6_stub->ipv6_dst_lookup_flow(a, b, c, d)
+#endif
+
 #if LINUX_VERSION_CODE < KERNEL_VERSION(3, 12, 0) && IS_ENABLED(CONFIG_IPV6) && !defined(ISRHEL7)
 #include <net/ipv6.h>
 struct ipv6_stub_type {

--- a/src/socket.c
+++ b/src/socket.c
@@ -136,8 +136,7 @@ static int send6(struct wg_device *wg, struct sk_buff *skb,
 			if (cache)
 				dst_cache_reset(cache);
 		}
-		dst = ipv6_stub->ipv6_dst_lookup_flow(sock_net(sock), sock, &fl,
-						      NULL);
+		dst = wg_ipv6_dst_lookup_flow(sock_net(sock), sock, &fl, NULL);
 		if (IS_ERR(dst)) {
 			ret = PTR_ERR(dst);
 			net_dbg_ratelimited("%s: No route to %pISpfsc, error %d\n",

--- a/src/socket.c
+++ b/src/socket.c
@@ -341,7 +341,11 @@ static void sock_free(struct sock *sock)
 	if (unlikely(!sock))
 		return;
 	sk_clear_memalloc(sock);
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(7, 1, 0)
+	udp_tunnel_sock_release(sock);
+#else
 	udp_tunnel_sock_release(sock->sk_socket);
+#endif
 }
 
 static void set_sock_opts(struct socket *sock)
@@ -395,14 +399,22 @@ retry:
 		goto out;
 	}
 	set_sock_opts(new4);
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(7, 1, 0)
+	setup_udp_tunnel_sock(net, new4->sk, &cfg);
+#else
 	setup_udp_tunnel_sock(net, new4, &cfg);
+#endif
 
 #if IS_ENABLED(CONFIG_IPV6)
 	if (ipv6_mod_enabled()) {
 		port6.local_udp_port = inet_sk(new4->sk)->inet_sport;
 		ret = udp_sock_create(net, &port6, &new6);
 		if (ret < 0) {
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(7, 1, 0)
+			udp_tunnel_sock_release(new4->sk);
+#else
 			udp_tunnel_sock_release(new4);
+#endif
 			if (ret == -EADDRINUSE && !port && retries++ < 100)
 				goto retry;
 			pr_err("%s: Could not create IPv6 socket\n",
@@ -410,7 +422,11 @@ retry:
 			goto out;
 		}
 		set_sock_opts(new6);
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(7, 1, 0)
+		setup_udp_tunnel_sock(net, new6->sk, &cfg);
+#else
 		setup_udp_tunnel_sock(net, new6, &cfg);
+#endif
 	}
 #endif
 

--- a/src/timers.c
+++ b/src/timers.c
@@ -8,6 +8,7 @@
 #include "peer.h"
 #include "queueing.h"
 #include "socket.h"
+#include <linux/kernel.h>
 
 /*
  * - Timer for retransmitting the handshake if we don't hear back after
@@ -40,7 +41,7 @@ static inline void mod_peer_timer(struct wg_peer *peer,
 
 static void wg_expired_retransmit_handshake(struct timer_list *timer)
 {
-	struct wg_peer *peer = timer_container_of(peer, timer,
+	struct wg_peer *peer = container_of(timer, struct wg_peer,
 						  timer_retransmit_handshake);
 
 	if (peer->timer_handshake_attempts > MAX_TIMER_HANDSHAKES) {
@@ -78,7 +79,7 @@ static void wg_expired_retransmit_handshake(struct timer_list *timer)
 
 static void wg_expired_send_keepalive(struct timer_list *timer)
 {
-	struct wg_peer *peer = timer_container_of(peer, timer,
+	struct wg_peer *peer = container_of(timer, struct wg_peer,
 						  timer_send_keepalive);
 
 	wg_packet_send_keepalive(peer);
@@ -91,7 +92,7 @@ static void wg_expired_send_keepalive(struct timer_list *timer)
 
 static void wg_expired_new_handshake(struct timer_list *timer)
 {
-	struct wg_peer *peer = timer_container_of(peer, timer,
+	struct wg_peer *peer = container_of(timer, struct wg_peer,
 						  timer_new_handshake);
 
 	pr_debug("%s: Retrying handshake with peer %llu (%pISpfsc) because we stopped hearing back after %d seconds\n",
@@ -106,7 +107,7 @@ static void wg_expired_new_handshake(struct timer_list *timer)
 
 static void wg_expired_zero_key_material(struct timer_list *timer)
 {
-	struct wg_peer *peer = timer_container_of(peer, timer,
+	struct wg_peer *peer = container_of(timer, struct wg_peer,
 						  timer_zero_key_material);
 
 	rcu_read_lock_bh();
@@ -137,7 +138,7 @@ static void wg_queued_expired_zero_key_material(struct work_struct *work)
 
 static void wg_expired_send_persistent_keepalive(struct timer_list *timer)
 {
-	struct wg_peer *peer = timer_container_of(peer, timer,
+	struct wg_peer *peer = container_of(timer, struct wg_peer,
 						  timer_persistent_keepalive);
 
 	if (likely(peer->persistent_keepalive_interval))


### PR DESCRIPTION
Fix IPv6 route lookup on kernels >= 7.1 without changing older-kernel behavior

This keeps the existing `ipv6_stub->ipv6_dst_lookup_flow(...)` path for older kernels and adds a compat wrapper for kernels `>= 7.1`, where it switches to `ip6_dst_lookup_flow(...)`.

Why:

- DKMS build failed on Fedora 44 with kernel `7.1.3-200.fc44.x86_64`
- failure was:
  `error: ‘ipv6_stub’ undeclared`
- after this compat change, the module builds successfully again

Validation:

- rebuilt `amneziawg` with DKMS on Fedora 44
- booted into `7.1.3-200.fc44.x86_64`
- `dkms status` shows the module installed for `7.1.3-200.fc44.x86_64`
- `modprobe amneziawg` succeeds
- Amnezia VPN tunnel works after reboot

This is a minimal compatibility fix confirmed on a real Fedora 44 system after kernel update from the 7.0 series to 7.1.3, while preserving the previous code path for older kernels.
