### PR TITLE
fix: ipv6_stub usage for kernel 7.x

### DIFF
--- a/src/socket.c
+++ b/src/socket.c
@@ -16,6 +16,7 @@
 #include <linux/inetdevice.h>
 #include <net/udp_tunnel.h>
 #include <net/ipv6.h>
+#include <net/ip6_route.h>
 
 static int send4(struct wg_device *wg, struct sk_buff *skb,
 		 struct endpoint *endpoint, u8 ds, struct dst_cache *cache)
@@ -136,8 +137,7 @@ static int send6(struct wg_device *wg, struct sk_buff *skb,
 			if (cache)
 				dst_cache_reset(cache);
 		}
-		dst = ipv6_stub->ipv6_dst_lookup_flow(sock_net(sock), sock, &fl,
-						      NULL);
+		dst = ip6_dst_lookup_flow(sock_net(sock), sock, &fl, NULL);
 		if (IS_ERR(dst)) {
 			ret = PTR_ERR(dst);
 			net_dbg_ratelimited("%s: No route to %pISpfsc, error %d\n",

--- a/src/socket.h
+++ b/src/socket.h
@@ -11,6 +11,10 @@
 #include <linux/if_vlan.h>
 #include <linux/if_ether.h>
 
+struct wg_device;
+struct wg_peer;
+struct endpoint;
+
 int wg_socket_init(struct wg_device *wg, u16 port);
 void wg_socket_reinit(struct wg_device *wg, struct sock *new4,
 		      struct sock *new6);


### PR DESCRIPTION
### Problem
On Linux kernels version 7.x and newer, the amneziawg-dkms module fails to build because the `ipv6_stub` symbol has been removed from the public API. This results in the compilation error `ipv6_stub undeclared` in `socket.c`.

### What fixed
1. Replaced the deprecated `ipv6_stub->ipv6_dst_lookup_flow` call in `socket.c` with a direct call to `ip6_dst_lookup_flow`, which is available when `CONFIG_IPV6=y`.
2. Added `#include <net/ip6_route.h>` to ensure the function is properly declared.
3. Added forward declarations for `struct wg_device`, `struct wg_peer`, and `struct endpoint` in `socket.h` to resolve type conflicts that occurred after the change.

### Testing
- Kernel: `7.1.3-zen1-1-zen` (Arch Linux)
- `CONFIG_IPV6=y`
- Build completed successfully; the module loads and the `awg-quick` interface comes up without errors.

#free_internet_for_everyone