### PR TITLE
fix: heap buffer overflow via negative-length junk-packet tags

### DIFF
--- a/src/junk.c
+++ b/src/junk.c
@@ -111,6 +111,8 @@ static int parse_r_tag(char* val, struct list_head* head) {
 
     if (!val || 0 > kstrtoint(val, 10, &len))
         return -EINVAL;
+    if (len < 0 || len > MESSAGE_MAX_SIZE)
+        return -EINVAL;
 
     tag = kzalloc(sizeof(*tag), GFP_KERNEL);
     if (!tag)
@@ -142,6 +144,8 @@ static int parse_rc_tag(char* val, struct list_head* head) {
 
     if (!val || 0 > kstrtoint(val, 10, &len))
         return -EINVAL;
+    if (len < 0 || len > MESSAGE_MAX_SIZE)
+        return -EINVAL;
 
     tag = kzalloc(sizeof(*tag), GFP_KERNEL);
     if (!tag)
@@ -168,6 +172,8 @@ static int parse_rd_tag(char* val, struct list_head* head) {
     int len;
 
     if (!val || 0 > kstrtoint(val, 10, &len))
+        return -EINVAL;
+    if (len < 0 || len > MESSAGE_MAX_SIZE)
         return -EINVAL;
 
     tag = kzalloc(sizeof(*tag), GFP_KERNEL);
@@ -289,7 +295,7 @@ int jp_spec_setup(struct jp_spec *spec) {
             ++mods_size;
     }
 
-    if (pkt_size > MESSAGE_MAX_SIZE) {
+    if (pkt_size < 0 || pkt_size > MESSAGE_MAX_SIZE) {
         err = -EINVAL;
         goto error;
     }


### PR DESCRIPTION
parse_r_tag(), parse_rc_tag(), and parse_rd_tag() parse the length
argument of <r N>, <rc N>, and <rd N> junk-packet tags (used in the
I1-I5 config options) via kstrtoint(), which accepts negative decimal
values. The result was stored into tag->pkt_size unchecked.

jp_spec_setup() sums every tag's pkt_size into a single int and
allocates a buffer of that size, bounds-checking only the sum against
MESSAGE_MAX_SIZE (never checking for a negative sum), then a second
pass copies each tag's *individual* size into the allocated buffer.

This lets a config combine a large real tag (e.g. <b 0x...1000 bytes
of hex...>) with a negative-length <r> tag so the summed pkt_size
comes out small and positive (passing the bounds check and producing
a small kzalloc'd buffer), while the fill loop still memcpy()s the
full-size real tag into that undersized buffer -- an immediate heap
buffer overflow. A negative-length <r> tag surviving into the modifier
list can also reach random_byte_modifier() -> get_random_bytes(buf,
len), where the negative int len sign-extends to a huge size_t,
causing a massive out-of-bounds write.

Since I1-I5 come directly from a .conf file's [Interface] section,
this is reachable by anyone who applies an AmneziaWG profile from an
untrusted source (a shared/downloaded config), not just local root
misconfiguration.

Fix: reject len < 0 (and > MESSAGE_MAX_SIZE) in all three tag parsers,
and add a matching lower-bound check on the aggregate pkt_size in
jp_spec_setup() as defense in depth.

Verified: on an unpatched module, 'awg set <if> i1 "<r -100>"' is
silently accepted; with this fix it's rejected with -EINVAL, while
valid tags like '<r 50>' continue to work normally.

