### PR TITLE
fix: unchecked allocations and a TOCTOU race on handshake paths

### DIFF
--- a/src/noise.c
+++ b/src/noise.c
@@ -626,15 +626,21 @@ wg_noise_handshake_consume_initiation(struct message_handshake_initiation *src,
 		static DEFINE_RATELIMIT_STATE(unknown_peer_notify_ratelimit,
 					      HZ, 10);
 
-		endpoint = kzalloc(sizeof(*endpoint), GFP_KERNEL);
-		if (unlikely(!endpoint))
-			goto out;
-		if (unlikely(wg_socket_endpoint_from_skb(endpoint, skb)))
-			goto out;
-
 		net_dbg_skb_ratelimited("%s: unknown peer from %pISpfsc\n", wg->dev->name, skb);
-		if (__ratelimit(&unknown_peer_notify_ratelimit))
+		/* Only allocate/populate the endpoint when we're actually going
+		 * to use it: under a flood of unknown-peer packets, __ratelimit()
+		 * rejects almost every call, and doing the kzalloc() +
+		 * wg_socket_endpoint_from_skb() first would mean paying that
+		 * cost on every rejected packet too.
+		 */
+		if (__ratelimit(&unknown_peer_notify_ratelimit)) {
+			endpoint = kzalloc(sizeof(*endpoint), GFP_KERNEL);
+			if (unlikely(!endpoint))
+				goto out;
+			if (unlikely(wg_socket_endpoint_from_skb(endpoint, skb)))
+				goto out;
 			wg_genl_mcast_peer_unknown(wg, s, endpoint, advanced_security);
+		}
 		goto out;
 	}
 	handshake = &peer->handshake;

--- a/src/noise.c
+++ b/src/noise.c
@@ -14,6 +14,7 @@
 #include "socket.h"
 
 #include <linux/rcupdate.h>
+#include <linux/ratelimit.h>
 #include <linux/slab.h>
 #include <linux/bitmap.h>
 #include <linux/scatterlist.h>
@@ -589,7 +590,7 @@ wg_noise_handshake_consume_initiation(struct message_handshake_initiation *src,
 {
 	struct wg_peer *peer = NULL, *ret_peer = NULL;
 	struct noise_handshake *handshake;
-	struct endpoint *endpoint = kzalloc(sizeof(*endpoint), GFP_KERNEL);
+	struct endpoint *endpoint = NULL;
 	bool replay_attack, flood_attack;
 	u8 key[NOISE_SYMMETRIC_KEY_LEN];
 	u8 chaining_key[NOISE_HASH_LEN];
@@ -622,11 +623,18 @@ wg_noise_handshake_consume_initiation(struct message_handshake_initiation *src,
 	/* Lookup which peer we're actually talking to */
 	peer = wg_pubkey_hashtable_lookup(wg->peer_hashtable, s);
 	if (!peer) {
+		static DEFINE_RATELIMIT_STATE(unknown_peer_notify_ratelimit,
+					      HZ, 10);
+
+		endpoint = kzalloc(sizeof(*endpoint), GFP_KERNEL);
+		if (unlikely(!endpoint))
+			goto out;
 		if (unlikely(wg_socket_endpoint_from_skb(endpoint, skb)))
 			goto out;
 
 		net_dbg_skb_ratelimited("%s: unknown peer from %pISpfsc\n", wg->dev->name, skb);
-		wg_genl_mcast_peer_unknown(wg, s, endpoint, advanced_security);
+		if (__ratelimit(&unknown_peer_notify_ratelimit))
+			wg_genl_mcast_peer_unknown(wg, s, endpoint, advanced_security);
 		goto out;
 	}
 	handshake = &peer->handshake;

--- a/src/send.c
+++ b/src/send.c
@@ -30,7 +30,7 @@ static void wg_packet_send_handshake_initiation(struct wg_peer *peer)
 	struct wg_device *wg = peer->device;
 	void *buffer;
 	u8 ds;
-	u16 junk_packet_count, junk_packet_size;
+	u16 junk_packet_count, junk_packet_size, jmin, jmax;
 	int i;
 	struct jp_spec* spec;
 
@@ -62,11 +62,19 @@ static void wg_packet_send_handshake_initiation(struct wg_peer *peer)
 			    &peer->endpoint.addr);
 
 		junk_packet_count = wg->jc;
-		buffer = kzalloc(wg->jmax, GFP_KERNEL);
+		/* Snapshot jmin/jmax once: they're read without device_update_lock
+		 * here, and re-reading wg->jmax on every loop iteration (instead of
+		 * using the same value the buffer below was sized with) would let a
+		 * concurrent 'wg set ... jmax N' race this loop into writing past
+		 * the end of a buffer sized for the old, smaller jmax.
+		 */
+		jmin = wg->jmin;
+		jmax = wg->jmax;
+		buffer = kzalloc(jmax, GFP_KERNEL);
 
 		if (likely(buffer)) {
 			while (junk_packet_count-- > 0) {
-				junk_packet_size = (u16) get_random_u32_inclusive(wg->jmin, wg->jmax);
+				junk_packet_size = (u16) get_random_u32_inclusive(jmin, jmax);
 
 				get_random_bytes(buffer, junk_packet_size);
 				get_random_bytes(&ds, 1);

--- a/src/send.c
+++ b/src/send.c
@@ -64,15 +64,17 @@ static void wg_packet_send_handshake_initiation(struct wg_peer *peer)
 		junk_packet_count = wg->jc;
 		buffer = kzalloc(wg->jmax, GFP_KERNEL);
 
-		while (junk_packet_count-- > 0) {
-			junk_packet_size = (u16) get_random_u32_inclusive(wg->jmin, wg->jmax);
+		if (likely(buffer)) {
+			while (junk_packet_count-- > 0) {
+				junk_packet_size = (u16) get_random_u32_inclusive(wg->jmin, wg->jmax);
 
-			get_random_bytes(buffer, junk_packet_size);
-			get_random_bytes(&ds, 1);
-			wg_socket_send_buffer_to_peer(peer, buffer, junk_packet_size, ds, 0);
+				get_random_bytes(buffer, junk_packet_size);
+				get_random_bytes(&ds, 1);
+				wg_socket_send_buffer_to_peer(peer, buffer, junk_packet_size, ds, 0);
+			}
+
+			kfree(buffer);
 		}
-
-		kfree(buffer);
 	}
 
 	if (wg_noise_handshake_create_initiation(&packet, &peer->handshake, mh_genheader(&wg->headers[MSGIDX_HANDSHAKE_INIT]))) {


### PR DESCRIPTION
Two allocations added for the advanced-security features had no NULL
check, each introducing a new crash mode not present in upstream
WireGuard (which does no allocation on either of these paths):

1. wg_noise_handshake_consume_initiation() (noise.c) unconditionally
   kzalloc'd a struct endpoint on *every* received handshake-initiation
   packet, authenticated or not, then dereferenced it unconditionally
   a few lines later in wg_socket_endpoint_from_skb() (an immediate
   memset through the pointer). Under memory pressure this is a remote,
   pre-authentication NULL-pointer dereference: anyone who can reach
   the UDP port and knows the server's public key (to pass the outer
   MAC1 check) can trigger it.

   Fix: only allocate the endpoint when it's actually needed (the
   unknown-peer branch), and check the result before using it. This
   also means known-peer traffic -- the common case -- no longer pays
   for an allocation it never used.

   While in there: the unknown-peer branch also unconditionally built
   and broadcast a genl multicast notification containing attacker-
   influenced bytes (the unauthenticated claimed peer pubkey) for every
   such packet, a new pre-auth allocation+broadcast cost on a path
   upstream just silently drops. Added a 10/sec ratelimit around it,
   checked *before* the allocation -- so a flood of unknown-peer
   packets that's mostly being rate-limited away doesn't still pay for
   the allocation on every rejected packet.

2. wg_packet_send_handshake_initiation() (send.c) allocates a
   wg->jmax-sized buffer for dummy junk packets (used when Jc/Jmax are
   configured) with no NULL check, then writes into it via
   get_random_bytes() unconditionally. This runs on the local transmit
   path for every handshake attempt when junk packets are enabled --
   an allocation failure would crash the box on its own outbound
   traffic, not an attacker-controlled path, but still a real
   robustness bug for anyone running with Jc/Jmax set (a fairly common
   'advanced security' configuration).

   Fix: skip sending dummy junk for that handshake attempt if the
   allocation fails, instead of writing through a NULL pointer.

3. Same function, found by an independent review pass before this was
   submitted upstream: wg->jc gets snapshotted into a local
   (junk_packet_count) before the send loop, but wg->jmin/wg->jmax did
   not -- the loop re-read the live wg->jmax on every iteration while
   using the value read *once* at kzalloc() time to size the buffer.
   This function runs without device_update_lock, so a concurrent
   'wg set <if> jmax N' (raising jmax) landing mid-loop lets
   get_random_bytes() write past the end of a buffer sized for the
   old, smaller jmax -- a heap buffer overflow triggered by two racing
   CAP_NET_ADMIN operations. Pre-existing bug, not introduced by fix
   #2 above, but same function and same buffer-safety concern, so
   fixed alongside it: snapshot jmin/jmax into locals once, same as jc,
   and use those consistently for both the allocation size and the
   loop's random range.

