### PR TITLE
fix: wrong cookie-reply size constant, UB shift in bogus_endpoints

### DIFF
--- a/src/netlink.c
+++ b/src/netlink.c
@@ -191,11 +191,13 @@ static inline int generate_ipv4_address_with_prefix(const struct ipv4_prefix *pr
 
 	prefix_host_order = ntohl(prefix->prefix);
 
-	if (prefix->prefix_len == 32) {
-		suffix_mask = 0;
-	} else {
-		suffix_mask = (1U << (32 - prefix->prefix_len)) - 1;
-	}
+	/* Compute in 64 bits so the shift (by up to 32) is always
+	 * well-defined, then narrow back to u32; prefix_len == 32 yields
+	 * (1ULL << 0) - 1 == 0 and prefix_len == 0 yields
+	 * (1ULL << 32) - 1 == 0xFFFFFFFF, both handled by this one
+	 * expression without a shift-by-width-of-type edge case.
+	 */
+	suffix_mask = (u32)((1ULL << (32 - prefix->prefix_len)) - 1);
 
 	get_random_bytes(&random_suffix, sizeof(random_suffix));
 	random_suffix &= suffix_mask;

--- a/src/receive.c
+++ b/src/receive.c
@@ -54,7 +54,7 @@ static size_t prepare_awg_message(struct sk_buff *skb, struct wg_device *wg)
 	if (skb->len == wg->junk_size[MSGIDX_HANDSHAKE_COOKIE] + MESSAGE_COOKIE_REPLY_SIZE) {
 		skb_pull(skb, wg->junk_size[MSGIDX_HANDSHAKE_COOKIE]);
 		if (mh_validate(SKB_TYPE_LE32(skb), &wg->headers[MSGIDX_HANDSHAKE_COOKIE]))
-			return MESSAGE_HANDSHAKE_COOKIE;
+			return MESSAGE_COOKIE_REPLY_SIZE;
 		else
 			skb_push(skb, wg->junk_size[MSGIDX_HANDSHAKE_COOKIE]);
 	}


### PR DESCRIPTION
Two small, independent correctness fixes found while auditing the
receive path and the (currently unused-by-default) bogus_endpoints
netlink feature:

1. receive.c: prepare_awg_message()'s handshake-cookie branch returned
   MESSAGE_HANDSHAKE_COOKIE (the message-TYPE enum value, 3) instead of
   MESSAGE_COOKIE_REPLY_SIZE (sizeof(struct message_handshake_cookie),
   ~60 bytes) -- a copy-paste mistake, since its three sibling branches
   (init/response/transport) correctly return their *_SIZE constant.
   The caller uses this return value as the length passed to
   pskb_may_pull(), so a wrong value here weakens that check for
   cookie-reply packets specifically.

   Not currently exploitable: prepare_awg_message() unconditionally
   skb_linearize()s any nonlinear skb before any type branch runs, and
   a linear skb already has its full length contiguous by definition,
   so the weakened pskb_may_pull() call downstream is already trivially
   satisfied regardless of the value passed to it. Fixed anyway since
   it's a clear bug and matches its siblings' pattern.

2. netlink.c: generate_ipv4_address_with_prefix() computed
   '1U << (32 - prefix_len)', which is undefined behavior when
   prefix_len == 0 (shift by the full width of the type). This is part
   of the bogus_endpoints feature (obfuscates peer endpoints in 'wg
   show' output within a configurable prefix), gated behind a
   module_param that defaults to disabled -- but it is a real,
   root-reachable code path once enabled with a /0 prefix, not
   unreachable.

   Fixed by computing the mask in 64 bits (1ULL << ...) before
   narrowing back to u32, so the shift amount (0-32) is always within
   the wider type's width -- one expression handles both the
   prefix_len == 0 and == 32 edge cases without branching. Verified
   the resulting suffix_mask against every multiple-of-8 prefix_len
   from 0 to 32 (0xffffffff, 0x00ffffff, 0x0000ffff, 0x000000ff, 0).

