### PR TITLE
Compile_error_fix

### DIFF
--- a/src/socket.c
+++ b/src/socket.c
@@ -341,7 +341,7 @@ static void sock_free(struct sock *sock)
 	if (unlikely(!sock))
 		return;
 	sk_clear_memalloc(sock);
-	udp_tunnel_sock_release(sock->sk_socket);
+	udp_tunnel_sock_release(sock->sk_socket->sk);
 }
 
 static void set_sock_opts(struct socket *sock)
@@ -395,14 +395,14 @@ retry:
 		goto out;
 	}
 	set_sock_opts(new4);
-	setup_udp_tunnel_sock(net, new4, &cfg);
+	setup_udp_tunnel_sock(net, new4->sk, &cfg);
 
 #if IS_ENABLED(CONFIG_IPV6)
 	if (ipv6_mod_enabled()) {
 		port6.local_udp_port = inet_sk(new4->sk)->inet_sport;
 		ret = udp_sock_create(net, &port6, &new6);
 		if (ret < 0) {
-			udp_tunnel_sock_release(new4);
+			udp_tunnel_sock_release(new4->sk);
 			if (ret == -EADDRINUSE && !port && retries++ < 100)
 				goto retry;
 			pr_err("%s: Could not create IPv6 socket\n",
@@ -410,7 +410,7 @@ retry:
 			goto out;
 		}
 		set_sock_opts(new6);
-		setup_udp_tunnel_sock(net, new6, &cfg);
+		setup_udp_tunnel_sock(net, new6->sk, &cfg);
 	}
 #endif
 


### PR DESCRIPTION
Arch Linux 7.1.5-arch1-1

Error during build

# Before
make -j16 KERNELRELEASE=7.1.5-arch1-1 -C /usr/lib/modules/7.1.5-arch1-1/build M=/var/lib/dkms/amneziawg/1.0.0/build
make: Entering directory '/usr/lib/modules/7.1.5-arch1-1/build'
make[1]: Entering directory '/var/lib/dkms/amneziawg/1.0.0/build'
  CC [M]  main.o
  CC [M]  noise.o
  CC [M]  device.o
  CC [M]  peer.o
  CC [M]  timers.o
  CC [M]  queueing.o
  CC [M]  send.o
  CC [M]  receive.o
  CC [M]  socket.o
  CC [M]  peerlookup.o
  CC [M]  allowedips.o
  CC [M]  ratelimiter.o
  CC [M]  cookie.o
  CC [M]  netlink.o
  CC [M]  junk.o
  CC [M]  magic_header.o
socket.c: In function ‘sock_free’:
socket.c:344:37: error: passing argument 1 of ‘udp_tunnel_sock_release’ from incompatible pointer type [-Wincompatible-pointer-types]
  344 |         udp_tunnel_sock_release(sock->sk_socket);
      |                                 ~~~~^~~~~~~~~~~
      |                                     |
      |                                     struct socket *
In file included from socket.c:17:
/usr/lib/modules/7.1.5-arch1-1/build/include/net/udp_tunnel.h:179:43: note: expected ‘struct sock *’ but argument is of type ‘struct socket *’
  179 | void udp_tunnel_sock_release(struct sock *sk);
      |                              ~~~~~~~~~~~~~^~
socket.c: In function ‘wg_socket_init’:
socket.c:398:36: error: passing argument 2 of ‘setup_udp_tunnel_sock’ from incompatible pointer type [-Wincompatible-pointer-types]
  398 |         setup_udp_tunnel_sock(net, new4, &cfg);
      |                                    ^~~~
      |                                    |
      |                                    struct socket *
/usr/lib/modules/7.1.5-arch1-1/build/include/net/udp_tunnel.h:97:58: note: expected ‘struct sock *’ but argument is of type ‘struct socket *’
   97 | void setup_udp_tunnel_sock(struct net *net, struct sock *sk,
      |                                             ~~~~~~~~~~~~~^~
socket.c:

# After
make -j16 KERNELRELEASE=7.1.5-arch1-1 -C /usr/lib/modules/7.1.5-arch1-1/build M=/var/lib/dkms/amneziawg/1.0.0/build
make: Entering directory '/usr/lib/modules/7.1.5-arch1-1/build'
make[1]: Entering directory '/var/lib/dkms/amneziawg/1.0.0/build'
  CC [M]  main.o
  CC [M]  noise.o
  CC [M]  device.o
  CC [M]  peer.o
  CC [M]  timers.o
  CC [M]  queueing.o
  CC [M]  send.o
  CC [M]  receive.o
  CC [M]  socket.o
  CC [M]  peerlookup.o
  CC [M]  ratelimiter.o
  CC [M]  allowedips.o
  CC [M]  cookie.o
  CC [M]  netlink.o
  CC [M]  junk.o
  CC [M]  magic_header.o
  LD [M]  amneziawg.o
  MODPOST Module.symvers
  CC [M]  amneziawg.mod.o
  CC [M]  .module-common.o
  LD [M]  amneziawg.ko
  BTF [M] amneziawg.ko
make[1]: Leaving directory '/var/lib/dkms/amneziawg/1.0.0/build'
make: Leaving directory '/usr/lib/modules/7.1.5-arch1-1/build'