### PR TITLE
fix: check IS_ERR(wg) before using the device in wg_set_device

### DIFF
--- a/src/header_protection.c
+++ b/src/header_protection.c
@@ -4,8 +4,13 @@
 #include <crypto/chacha.h>
 
 inline bool awg_has_header_protection(struct wg_device *wg) {
-	struct header_protection* p = &wg->header_protection;
+	struct header_protection* p;
 	bool res;
+
+	if (IS_ERR_OR_NULL(wg))
+		return false;
+
+	p = &wg->header_protection;
 	down_read(&p->lock);
 	res = p->has_protection;
 	up_read(&p->lock);

--- a/src/header_protection.c
+++ b/src/header_protection.c
@@ -36,8 +36,8 @@ out:
 	return res;
 }
 
-void awg_header_protection_set_key(struct header_protection *p, u8 key[HEADER_PROTECTION_KEY_SIZE]) {	
-	down_read(&p->lock);
+void awg_header_protection_set_key(struct header_protection *p, u8 key[HEADER_PROTECTION_KEY_SIZE]) {
+	down_write(&p->lock);
 	p->key[0] = get_unaligned_le32(key + 0);
 	p->key[1] = get_unaligned_le32(key + 4);
 	p->key[2] = get_unaligned_le32(key + 8);
@@ -47,7 +47,7 @@ void awg_header_protection_set_key(struct header_protection *p, u8 key[HEADER_PR
 	p->key[6] = get_unaligned_le32(key + 24);
 	p->key[7] = get_unaligned_le32(key + 28);
 	p->has_protection = true;
-	up_read(&p->lock);
+	up_write(&p->lock);
 }
 
 void awg_header_protection_get_key(struct header_protection *p, u8 key[HEADER_PROTECTION_KEY_SIZE]) {

--- a/src/netlink.c
+++ b/src/netlink.c
@@ -749,13 +749,15 @@ static int wg_set_device(struct sk_buff *skb, struct genl_info *info)
 	u32 flags = 0;
 	int ret;
 	u16 val16;
-	bool has_protection = awg_has_header_protection(wg) ||
-		info->attrs[WGDEVICE_A_HEADER_PROTECTION_KEY];
+	bool has_protection;
 
 	if (IS_ERR(wg)) {
 		ret = PTR_ERR(wg);
 		goto out_nodev;
 	}
+
+	has_protection = awg_has_header_protection(wg) ||
+		info->attrs[WGDEVICE_A_HEADER_PROTECTION_KEY];
 
 	rtnl_lock();
 	mutex_lock(&wg->device_update_lock);


### PR DESCRIPTION
`wg_set_device()` initialises `has_protection` from `awg_has_header_protection(wg)`
in the declaration block, above the `IS_ERR(wg)` check. When the request names an
interface that doesn't exist, `lookup_interface()` returns an `ERR_PTR` and the
helper dereferences it right away.

The oops lands inside `down_read()`, and `genl_rcv_msg()` holds the genl family
lock across the `doit` callback, so the lock is never released. Everything on the
`amneziawg` family blocks in uninterruptible sleep from then on — including
`awg setconf` for tunnels that were up and working — and `genl_unregister_family()`
hangs too, so the module can neither be used nor unloaded. Only a reboot clears it.
`rmmod -f` isn't a way out either, since stock Ubuntu kernels build without
`CONFIG_MODULE_FORCE_UNLOAD`.

```
BUG: kernel NULL pointer dereference, address: 000000000000050d
Oops: 0002 [#1] PREEMPT SMP NOPTI
RIP: 0010:down_read+0x1e/0xc0
Call Trace:
 <TASK>
 awg_has_header_protection+0x19/0x50 [amneziawg]
 wg_set_device+0x43/0xe50 [amneziawg]
 ? genl_family_rcv_msg_attrs_parse.constprop.0+0x93/0x100
 genl_family_rcv_msg_doit+0xfa/0x160
 genl_family_rcv_msg+0x189/0x260
 ? __pfx_wg_set_device+0x10/0x10 [amneziawg]
 genl_rcv_msg+0x4c/0xb0
 genl_rcv+0x28/0x50
 </TASK>
note: awg[80691] exited with irqs disabled
note: awg[80691] exited with preempt_count 1
```

`CR2` being `0x50d` rather than a near-zero address is the `ERR_PTR` giveaway:
`(void *)-19` plus the offset of `header_protection.lock` in `struct wg_device`.

The call is the left operand of the `||`, so it runs whether or not
`WGDEVICE_A_HEADER_PROTECTION_KEY` was passed — a plain
`awg set doesnotexist listen-port 51820` reaches it too. Introduced in #192.

The first commit moves the check above the use. It also adds an
`IS_ERR_OR_NULL()` guard inside `awg_has_header_protection()`, since it takes a
device pointer from several call sites.

The second commit is unrelated to the crash but in the same file:
`awg_header_protection_set_key()` writes `p->key[]` and `p->has_protection`
while holding only `down_read()`. Concurrent setters can interleave, and
`awg_header_protection_init()` can read a half-updated key while building the
chacha state — silently wrong header protection rather than a reported error.
Happy to split it out if you'd rather keep this PR to the crash.

## Verification

Built and run against 6.8.0-136-generic (Ubuntu 22.04.5), on the same host
where the oops was originally hit.

Before, on `3.0.20260731-04` from `ppa:amnezia/ppa`:

```console
# awg set doesnotexist header-protection-key /dev/null
Killed
# echo $?
137
# awg-quick up awg0        # hangs, unkillable
# ps -eo pid,stat,wchan:24,cmd | awk '$2 ~ /D/'
  81680 D    genl_rcv_msg             awg setconf awg0 /dev/fd/63
  82328 D    genl_unregister_fami     rmmod amneziawg
```

After, with this branch:

```console
# awg set doesnotexist header-protection-key /dev/null
Unable to modify interface: No such device
# echo $?
1
# awg set doesnotexist listen-port 51820
Unable to modify interface: No such device
# echo $?
1
# ps -eo pid,stat,cmd | awk '$2 ~ /D/' | wc -l
0
```

`dmesg` is clean, and an existing AWG 3 tunnel (with `HeaderProtectionKey` set)
comes back up on the patched module and passes traffic as before.