### PR TITLE
fix: read is_keepalive before sending skb

### DIFF
--- a/src/send.c
+++ b/src/send.c
@@ -344,8 +344,10 @@ static void wg_packet_create_data_done(struct wg_peer *peer, struct sk_buff *fir
 	wg_timers_any_authenticated_packet_traversal(peer);
 	wg_timers_any_authenticated_packet_sent(peer);
 	skb_list_walk_safe(first, skb, next) {
+		bool is_keepalive = PACKET_CB(skb)->is_keepalive;
+
 		if (likely(!wg_socket_send_skb_to_peer(peer, skb,
-				PACKET_CB(skb)->ds) && !PACKET_CB(skb)->is_keepalive))
+				PACKET_CB(skb)->ds) && !is_keepalive))
 			data_sent = true;
 	}
 


### PR DESCRIPTION
## Summary
- After `ce16310`, keepalive detection uses `PACKET_CB(skb)->is_keepalive`.
- The flag was read **after** `wg_socket_send_skb_to_peer()`, which consumes the skb.
- The network stack reuses `skb->cb`, so the bool can become garbage (UBSAN: `load of value 51 is not a valid value for type '_Bool'` in `send.c` / `wg_packet_tx_worker`).

## Fix
Capture `is_keepalive` into a local before sending, matching the pre-`ce16310` pattern that evaluated keepalive status before transmit.

## Test plan
- [x] Rebuild DKMS module and load it
- [x] Run traffic + keepalives with `S4` / `ContentPaddingAddition` enabled
- [ ] Confirm no UBSAN `invalid-load` in `send.c` / `wg_packet_tx_worker`


Made with [Cursor](https://cursor.com)