### PR TITLE
fix: initialize header_protection.lock, use down_write in set_key

### DIFF
--- a/src/device.c
+++ b/src/device.c
@@ -355,6 +355,7 @@ static int wg_newlink(struct net_device *dev,
 
 	rcu_assign_pointer(wg->creating_net, link_net);
 	init_rwsem(&wg->static_identity.lock);
+	init_rwsem(&wg->header_protection.lock);
 	mutex_init(&wg->socket_update_lock);
 	mutex_init(&wg->device_update_lock);
 	for (i = 0; i < ARRAY_SIZE(wg->ispecs); ++i)

--- a/src/header_protection.c
+++ b/src/header_protection.c
@@ -22,8 +22,8 @@ out:
 	return res;
 }
 
-void awg_header_protection_set_key(struct header_protection *p, u8 key[HEADER_PROTECTION_KEY_SIZE]) {	
-	down_read(&p->lock);
+void awg_header_protection_set_key(struct header_protection *p, u8 key[HEADER_PROTECTION_KEY_SIZE]) {
+	down_write(&p->lock);
 	p->key[0] = get_unaligned_le32(key + 0);
 	p->key[1] = get_unaligned_le32(key + 4);
 	p->key[2] = get_unaligned_le32(key + 8);
@@ -33,7 +33,7 @@ void awg_header_protection_set_key(struct header_protection *p, u8 key[HEADER_PR
 	p->key[6] = get_unaligned_le32(key + 24);
 	p->key[7] = get_unaligned_le32(key + 28);
 	p->has_protection = true;
-	up_read(&p->lock);
+	up_write(&p->lock);
 }
 
 void awg_header_protection_get_key(struct header_protection *p, u8 key[HEADER_PROTECTION_KEY_SIZE]) {


### PR DESCRIPTION
Closes #216.

## Root cause

Two independent bugs in `header_protection.c`:

1. `header_protection.lock` (an `rw_semaphore`) is never initialized via `init_rwsem()` anywhere in the driver. It's only zero-filled via `memset(wg, 0, sizeof(*wg))` in `wg_setup()`. Every other rwsem in the driver (`cookie->lock`, `wg->static_identity.lock`, `handshake->lock`) does get `init_rwsem()`'d — this one was missed. Using an uninitialized `rw_semaphore` is undefined behavior.

2. `awg_header_protection_set_key()` mutates `p->key[]` and `p->has_protection` while holding only `down_read()`, not `down_write()`. In fact all three functions in the file (`init`, `set_key`, `get_key`) use `down_read()` — there's no writer path at all, so there's effectively no mutual exclusion for the mutation.

Together these explain `setconf` failing with `Unable to modify interface: Invalid argument` when `HeaderProtectionKey` is set, even with valid S1-S4 values (well above `HEADER_PROTECTION_NONCE_SIZE`) — reproduction details are in #216.

## Fix

- Add `init_rwsem(&wg->header_protection.lock)` in `wg_newlink()`, next to the other lock initializations.
- Change `awg_header_protection_set_key()` to use `down_write()`/`up_write()`.

## Testing

Built via DKMS against a patched local checkout, loaded on a real server (Ubuntu 24.04, arm64, kernel 6.17.0-1014-oracle), confirmed `setconf` with `HeaderProtectionKey` set succeeds, `header protection key` shows correctly in `awg show`, and a full handshake + real traffic works end to end.