### PR TITLE
socket: fix udp_tunnel_sock_release/setup_udp_tunnel_sock ABI mismatch on newer kernels

### DIFF
--- a/src/compat/compat.h
+++ b/src/compat/compat.h
@@ -1444,11 +1444,36 @@ static inline void __compat_chacha20_crypt(struct chacha_state *state,
 
 #endif
 
-#if LINUX_VERSION_CODE < KERNEL_VERSION(7, 1, 5)
+/*
+ * Some very recent kernel snapshots (not yet in an official release at the
+ * time of writing) changed udp_tunnel_sock_release()/setup_udp_tunnel_sock()
+ * to take a struct sock * instead of a struct socket *. LINUX_VERSION_CODE
+ * can't reliably gate this, since some distros (e.g. CachyOS) backport it
+ * early under an unchanged version number. Detect the real signature at
+ * compile time instead.
+ */
 #include <net/udp_tunnel.h>
-#define setup_udp_tunnel_sock(net, sk, sock_cfg) setup_udp_tunnel_sock(net, sk->sk_socket, sock_cfg)
-#define udp_tunnel_sock_release(sk) udp_tunnel_sock_release(sk->sk_socket)
-#endif
+
+static inline void __compat_udp_tunnel_sock_release(struct sock *sk)
+{
+	if (__builtin_types_compatible_p(typeof(&udp_tunnel_sock_release), void (*)(struct sock *)))
+		((void (*)(struct sock *))udp_tunnel_sock_release)(sk);
+	else
+		((void (*)(struct socket *))udp_tunnel_sock_release)(sk->sk_socket);
+}
+
+static inline void __compat_setup_udp_tunnel_sock(struct net *net, struct sock *sk,
+						    struct udp_tunnel_sock_cfg *cfg)
+{
+	if (__builtin_types_compatible_p(typeof(&setup_udp_tunnel_sock),
+					  void (*)(struct net *, struct sock *, struct udp_tunnel_sock_cfg *)))
+		((void (*)(struct net *, struct sock *, struct udp_tunnel_sock_cfg *))setup_udp_tunnel_sock)(net, sk, cfg);
+	else
+		((void (*)(struct net *, struct socket *, struct udp_tunnel_sock_cfg *))setup_udp_tunnel_sock)(net, sk->sk_socket, cfg);
+}
+
+#define udp_tunnel_sock_release(sk) __compat_udp_tunnel_sock_release(sk)
+#define setup_udp_tunnel_sock(net, sk, cfg) __compat_setup_udp_tunnel_sock(net, sk, cfg)
 
 #if LINUX_VERSION_CODE < KERNEL_VERSION(6, 18, 0)
 #define WQ_PERCPU 0


### PR DESCRIPTION
## Root cause

Very recent kernel snapshots (not yet in an official release at the time of writing) changed the signature of `udp_tunnel_sock_release()` and `setup_udp_tunnel_sock()` from taking a `struct socket *` to taking a `struct sock *`. Some distro kernels (e.g. CachyOS) backport this early, under an unchanged `LINUX_VERSION_CODE` — so this can't reliably be gated by kernel version, only by the actual declared signature.

Build failure on affected kernels:
```
socket.c:378:26: error: incompatible pointer types passing 'struct socket *' to parameter of type 'struct sock *' [-Wincompatible-pointer-types]
socket.c:432:29: error: incompatible pointer types passing 'struct socket *' to parameter of type 'struct sock *' [-Wincompatible-pointer-types]
socket.c:439:28: error: incompatible pointer types passing 'struct socket *' to parameter of type 'struct sock *' [-Wincompatible-pointer-types]
socket.c:447:30: error: incompatible pointer types passing 'struct socket *' to parameter of type 'struct sock *' [-Wincompatible-pointer-types]
```

## Fix

Added two small wrappers (`wg_udp_tunnel_sock_release`, `wg_setup_udp_tunnel_sock`) that detect the real parameter type at compile time via `__builtin_types_compatible_p(typeof(&fn), ...)`, then call through an explicitly-cast function pointer matching whichever signature is actually declared. This avoids any `LINUX_VERSION_CODE` guessing and works correctly regardless of which ABI the currently-built-against headers expose.

## Testing

Built via DKMS on a CachyOS system (kernel `7.1.8-1-cachyos`, where this previously failed to build at all). Build now succeeds and the module loads and passes real traffic. Also confirmed it still builds and works correctly against an older/unaffected kernel (Ubuntu 24.04, `6.17.0-1014-oracle`), so both ABI variants are covered.