### PR TITLE
fix: do not append random trailers to I1-I5 and dummy junk packets

### DIFF
--- a/src/send.c
+++ b/src/send.c
@@ -53,7 +53,7 @@ static void wg_packet_send_handshake_initiation(struct wg_peer *peer)
 		if (spec->pkt_size > 0) {
 			mutex_lock(&spec->lock);
 			jp_spec_applymods(spec, peer);
-			wg_socket_send_buffer_to_peer(peer, spec->pkt, spec->pkt_size, 0, 0);
+			wg_socket_send_buffer_to_peer(peer, spec->pkt, spec->pkt_size, 0, 0, false);
 			atomic_inc(&peer->jp_packet_counter);
 			mutex_unlock(&spec->lock);
 		}
@@ -72,7 +72,7 @@ static void wg_packet_send_handshake_initiation(struct wg_peer *peer)
 
 			get_random_bytes(buffer, junk_packet_size);
 			get_random_bytes(&ds, 1);
-			wg_socket_send_buffer_to_peer(peer, buffer, junk_packet_size, ds, 0);
+			wg_socket_send_buffer_to_peer(peer, buffer, junk_packet_size, ds, 0, false);
 		}
 
 		kfree(buffer);
@@ -86,7 +86,7 @@ static void wg_packet_send_handshake_initiation(struct wg_peer *peer)
 		atomic64_set(&peer->last_sent_handshake,
 			     ktime_get_coarse_boottime_ns());
 		wg_socket_send_buffer_to_peer(peer, &packet, sizeof(packet),
-					      HANDSHAKE_DSCP, wg->init_padding);
+					      HANDSHAKE_DSCP, wg->init_padding, true);
 		wg_timers_handshake_initiated(peer);
 	}
 }
@@ -158,7 +158,7 @@ void wg_packet_send_handshake_response(struct wg_peer *peer)
 			wg_socket_send_buffer_to_peer(peer, &packet,
 						      sizeof(packet),
 						      HANDSHAKE_DSCP,
-							  wg->resp_padding);
+							  wg->resp_padding, true);
 		}
 	}
 }

--- a/src/socket.c
+++ b/src/socket.c
@@ -187,14 +187,16 @@ int wg_socket_send_skb_to_peer(struct wg_peer *peer, struct sk_buff *skb, u8 ds)
 }
 
 int wg_socket_send_buffer_to_peer(struct wg_peer *peer, void *buffer,
-				  size_t len, u8 ds, size_t padding)
+				  size_t len, u8 ds, size_t padding, bool trailer)
 {
 	struct sk_buff *skb;
 	void *crypto = NULL;
 	size_t trailer_len;
 	struct chacha_state state;
 
-	trailer_len = wg_peer_skb_random_trailer(peer, peer->device, padding + len);
+	trailer_len = trailer
+		? wg_peer_skb_random_trailer(peer, peer->device, padding + len)
+		: 0;
 	
 	skb = alloc_skb(len + padding + trailer_len + SKB_HEADER_LEN, GFP_ATOMIC);
 	if (unlikely(!skb))

--- a/src/socket.h
+++ b/src/socket.h
@@ -15,7 +15,7 @@ int wg_socket_init(struct wg_device *wg, u16 port);
 void wg_socket_reinit(struct wg_device *wg, struct sock *new4,
 		      struct sock *new6);
 int wg_socket_send_buffer_to_peer(struct wg_peer *peer, void *data,
-				  size_t len, u8 ds, size_t padding);
+				  size_t len, u8 ds, size_t padding, bool trailer);
 int wg_socket_send_skb_to_peer(struct wg_peer *peer, struct sk_buff *skb,
 			       u8 ds);
 int wg_socket_send_buffer_as_reply_to_skb(struct wg_device *wg,


### PR DESCRIPTION
Fixes https://github.com/amnezia-vpn/amneziawg-linux-kernel-module/issues/231

  ## What

  Stop appending random trailers to the `I1`-`I5` special junk packets and to the
  `Jc` dummy junk. Handshake initiation, handshake response, cookie reply and
  transport padding are unchanged.

  ## Why

  `I1`-`I5` are operator-supplied byte-exact covers. A random tail does not
  obscure their shape, it destroys it and replaces it with something the imitated
  protocol can never produce: a valid prefix followed by bytes that protocol never
  carries. For the dummy junk the trailer is simply redundant, its length is
  already drawn from `[Jmin, Jmax]`.

  ## amneziawg-go already does this

  Checked at `b5928efb6ca19f0153958460c3d141f04abc5c2e`: I-packets are queued as
  `make([]byte, ipacket.ObfuscatedLen(0))` with no trailer term
  (`device/send.go:139-144`), and `randomTrailer()` is called only for handshake
  init (`:150`), response (`:200`), cookie reply (`:259`) and transport padding
  (`:609`). `JunkPackets()` is untouched too. So the same `.conf` currently gives
  a different wire footprint depending on which implementation runs it. This makes
  the kernel module match Go.

  ## How

  `wg_socket_send_buffer_to_peer()` gains a `bool trailer` argument. The four call
  sites in `send.c` pass `false` for the ispec loop and the dummy junk, `true` for
  the two handshake messages. `+9 -7` across `send.c`, `socket.c`, `socket.h`.

  No UAPI, netlink or wire-format change: I-packets and dummy junk are never
  parsed by the receiver, so patched and unpatched ends interoperate unchanged.

  ## Testing

  Builds clean with no new warnings against `6.12.107+deb13-amd64`.